### PR TITLE
node 버전 및 yarn 사용 강제

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
     "eslint": "8.7.0",
     "eslint-config-next": "12.0.8",
     "typescript": "4.5.5"
+  },
+  "engines": {
+    "node": "^16.13.0",
+    "npm": "please-use-yarn",
+    "yarn": "^1.22.17"
   }
 }


### PR DESCRIPTION
## Summary

- `.npmrc`를 이용해 `engine-strict=true` 플래그를 설정하였습니다.
- `package.json`의 `engines` 필드에 `node` 버전 및 `yarn` 버전의 범위를 지정하였습니다.

## Detail

- `node` 버전은 v16.13.0 < 17.0.0 사이의 버전을 사용하도록 강제하였습니다.
- `npm`을 사용하려 하면 `please-use-yarn`이라는 에러 메시지를 출력하게끔 하였습니다.
- `yarn`의 경우 v1.22.17(yarn classic stable) < 2.0.0 버전 사용을 강제하였습니다.
![image](https://user-images.githubusercontent.com/37530109/151135773-945d5d8b-04b6-45e6-84c5-832d214a18ca.png)



## Issue

- 상세한 내용은 브랜딩팀 노션 -> 지원/어드민 페이지 -> 웹 문서 -> 이슈에 정리해두었습니다.
- `.nvmrc`의 경우 아직 추가해두지는 않았는데 사용한다면 프로젝트 루트에서 `nvm use`를 수행하는 것을 강제하거나 파이프라인에 포함시킬 수 있는 방법을 같이 고민해보면 좋을 듯 합니다.