### PR TITLE
Accordion 컴포넌트 구현

### DIFF
--- a/src/assets/svg/minus.svg
+++ b/src/assets/svg/minus.svg
@@ -1,0 +1,3 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 22H28" stroke="#343A40" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svg/plus.svg
+++ b/src/assets/svg/plus.svg
@@ -1,0 +1,4 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 22H28" stroke="#343A40" stroke-width="2" stroke-linecap="round"/>
+<path d="M22 28V16" stroke="#343A40" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/common/Accordion/Accordion.component.tsx
+++ b/src/components/common/Accordion/Accordion.component.tsx
@@ -1,0 +1,58 @@
+import { useRef, useState } from 'react';
+import Plus from '@/assets/svg/plus.svg';
+import Minus from '@/assets/svg/minus.svg';
+import * as Styled from './Accordion.styled';
+
+interface AccordionProps {
+  id: string;
+  title: string;
+  content: string;
+  headingTagName?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+const Accordion = ({ id, title, content, headingTagName }: AccordionProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+
+  const handleClickButton = () => {
+    if (!(panelRef.current && contentRef.current)) return;
+
+    panelRef.current.style.height = `${isExpanded ? 0 : contentRef.current.offsetHeight}px`;
+
+    setIsExpanded(!isExpanded);
+  };
+
+  const Icon = isExpanded ? Minus : Plus;
+
+  return (
+    <Styled.Accordion>
+      <Styled.Header as={headingTagName}>
+        <button
+          type="button"
+          onClick={handleClickButton}
+          id={`${id}-header`}
+          aria-expanded={isExpanded}
+          aria-controls={`${id}-panel`}
+        >
+          {title}
+          <Icon aria-hidden />
+        </button>
+      </Styled.Header>
+      <Styled.Panel
+        id={`${id}-panel`}
+        aria-hidden={!isExpanded}
+        aria-labelledby={`${id}-header`}
+        ref={panelRef}
+      >
+        <p ref={contentRef}>{content}</p>
+      </Styled.Panel>
+    </Styled.Accordion>
+  );
+};
+
+export default Accordion;
+
+Accordion.defaultProps = {
+  headingTagName: 'h3',
+};

--- a/src/components/common/Accordion/Accordion.component.tsx
+++ b/src/components/common/Accordion/Accordion.component.tsx
@@ -10,7 +10,7 @@ interface AccordionProps {
   headingTagName?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
-const Accordion = ({ id, title, content, headingTagName }: AccordionProps) => {
+const Accordion = ({ id, title, content, headingTagName = 'h3' }: AccordionProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLParagraphElement>(null);
@@ -31,18 +31,18 @@ const Accordion = ({ id, title, content, headingTagName }: AccordionProps) => {
         <button
           type="button"
           onClick={handleClickButton}
-          id={`${id}-header`}
+          id={`header-${id}`}
           aria-expanded={isExpanded}
-          aria-controls={`${id}-panel`}
+          aria-controls={`panel-${id}`}
         >
           {title}
           <Icon aria-hidden />
         </button>
       </Styled.Header>
       <Styled.Panel
-        id={`${id}-panel`}
+        id={`panel-${id}`}
         aria-hidden={!isExpanded}
-        aria-labelledby={`${id}-header`}
+        aria-labelledby={`header-${id}`}
         ref={panelRef}
       >
         <p ref={contentRef}>{content}</p>
@@ -52,7 +52,3 @@ const Accordion = ({ id, title, content, headingTagName }: AccordionProps) => {
 };
 
 export default Accordion;
-
-Accordion.defaultProps = {
-  headingTagName: 'h3',
-};

--- a/src/components/common/Accordion/Accordion.stories.tsx
+++ b/src/components/common/Accordion/Accordion.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Accordion from './Accordion.component';
+
+export default {
+  title: 'Accordion',
+  component: Accordion,
+} as ComponentMeta<typeof Accordion>;
+
+const Template: ComponentStory<typeof Accordion> = (args) => {
+  return (
+    <>
+      <Accordion {...args} />
+      <Accordion {...args} />
+      <Accordion {...args} />
+      <Accordion {...args} />
+      <Accordion {...args} />
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  id: '1',
+  title: '노드에 대해 얼마나 알아야 지원할 수 있나요?',
+  content:
+    '면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용면접일정 관련 답변내용',
+  headingTagName: 'h3',
+};

--- a/src/components/common/Accordion/Accordion.styled.ts
+++ b/src/components/common/Accordion/Accordion.styled.ts
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Accordion = styled.div`
+  ${({ theme }) => css`
+    & > *:not([aria-hidden='true']) {
+      margin: 2rem 0;
+    }
+
+    border-bottom: 0.1rem solid ${theme.colors.gray20};
+  `}
+`;
+
+export const Header = styled.h3`
+  ${({ theme }) => css`
+    button {
+      ${theme.fonts.kr.bold22};
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      padding: 0;
+      background: ${theme.colors.white};
+      border: 0;
+    }
+  `}
+`;
+
+export const Panel = styled.div`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.regular15};
+    height: 0;
+    overflow: hidden;
+    transition: height 0.35s ease;
+  `}
+`;


### PR DESCRIPTION
## 변경사항

- [링크](https://www.aditus.io/patterns/accordion/)를 참고하여 가급적 접근성을 확보하게끔 노력해보았습니다 :)
- aria-labeledby와 aria-controls를 연동시키기 위해서 고유한 id를 필수적으로 전달받도록 구현하였습니다.
- 우선은 각 아코디언이 화면 전체의 너비를 차지하게끔 해두었는데 이를 사용하는 페이지에서 반응형 디자인에 따라 화면 사이즈를 조절할 수 있게끔 할 계획입니다
- 피그마 디자인 상으로는 아코디언이 펼쳐졌다가 닫힐 때 별도의 애니메이션이 없는 것으로 되어 있는데 우선은 height에 대해 임의의 애니메이션을 추가해둔 상태로 애니메이션 확정되면 수정할 계획입니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
