### PR TITLE
라우트 이동시 Header의 background에 transition이 먹는 이슈 Fix

### DIFF
--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -4,17 +4,23 @@ import { useDetectViewPort, useWatchingIsScrollTop } from '@/hooks';
 import MashUpLogo24 from '@/assets/svg/mash-up-logo-24.svg';
 import MashUpLogo33 from '@/assets/svg/mash-up-logo-33.svg';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import * as Styled from './Header.styled';
 
 const Header = () => {
+  const [isHome, setIsHome] = useState(false);
   const { size } = useDetectViewPort();
-
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (asPath === HOME_PAGE) setIsHome(true);
+    else setIsHome(false);
+  }, [asPath]);
 
   const isScrollTop = useWatchingIsScrollTop();
 
   return (
-    <Styled.Header isScrollTop={isScrollTop} currentPage={asPath}>
+    <Styled.Header isScrollTop={isScrollTop} currentPage={asPath} isHome={isHome}>
       <Styled.HeaderInner>
         <LinkTo href={HOME_PAGE}>
           <Styled.Heading

--- a/src/components/common/Header/Header.styled.ts
+++ b/src/components/common/Header/Header.styled.ts
@@ -5,26 +5,26 @@ import styled from '@emotion/styled';
 interface HeaderProps {
   isScrollTop: boolean;
   currentPage: string;
+  isHome: boolean;
 }
 
 export const Header = styled.header<HeaderProps>`
-  ${({ theme, isScrollTop, currentPage }) => css`
+  ${({ theme, isScrollTop, currentPage, isHome }) => css`
     position: fixed;
     z-index: ${theme.zIndex.header};
     width: 100%;
     height: 8rem;
     padding: 1.7rem 0;
-    ${(() =>
-      isScrollTop && currentPage === HOME_PAGE
-        ? css`
-            background: ${theme.colors.black};
-          `
-        : css`
-            background: rgba(255, 255, 255, 0.7);
-            backdrop-filter: blur(2rem);
-          `)()};
+    ${isScrollTop && currentPage === HOME_PAGE
+      ? css`
+          background: ${theme.colors.black};
+        `
+      : css`
+          background: rgba(255, 255, 255, 0.7);
+          backdrop-filter: blur(2rem);
+        `};
 
-    transition: ${isScrollTop ? 0 : '0.5s'};
+    transition: ${isHome ? '0.5s' : 0};
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       height: 6rem;


### PR DESCRIPTION
## 변경사항

- 라우트 변경시 Header 컴포넌트의 background에 transition이 먹는 이슈를 Fix하였습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
