### PR TITLE
Feat: 항상 Footer Component가 앱 최하단에 위치하도록 css 적용

### DIFF
--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -8,11 +8,11 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <>
+    <Styled.AppWrapper>
       <Header />
       <Styled.Layout>{children}</Styled.Layout>
       <Footer />
-    </>
+    </Styled.AppWrapper>
   );
 };
 

--- a/src/components/common/Layout/Layout.styled.ts
+++ b/src/components/common/Layout/Layout.styled.ts
@@ -1,9 +1,16 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+export const AppWrapper = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  min-height: 100vh;
+`;
+
 export const Layout = styled.main`
   ${({ theme }) => css`
     position: relative;
+    flex-grow: 1;
     padding-top: 8rem;
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {


### PR DESCRIPTION
## 변경사항

- 자주묻는 질문 페이지 등 화면의 전체 높이보다 height값이 낮은 페이지들에도 footer가 항상 최하단에 위치하도록 Header, Layout, Footer 컴포넌트를 하나의 div요소로 감싸 flex flow를 column, nowrap으로, min-height를 100vh로 설정하고 Layout영역에 `flex-grow:1;` 값을 부여해 항상 Header와 Footer는 앱의 최상단, 최하단에 위치하도록 해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
