### PR TITLE
next-auth 사용 시 로그인 API가 연속해서 호출되는 문제 해결

### DIFF
--- a/@types/custom-types/next-auth.d.ts
+++ b/@types/custom-types/next-auth.d.ts
@@ -9,6 +9,6 @@ declare module 'next-auth' {
 
 declare module 'next-auth/jwt' {
   export interface JWT {
-    googleIdToken?: string;
+    accessToken?: string;
   }
 }

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -12,18 +12,19 @@ export default NextAuth({
   secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
     async session({ session, token }) {
-      const {
-        data: { accessToken },
-      } = await applicantApiService.signIn({ googleIdToken: token.googleIdToken! });
+      if (token.accessToken) {
+        return { ...session, accessToken: token.accessToken };
+      }
 
-      // eslint-disable-next-line no-param-reassign
-      session.accessToken = accessToken;
       return session;
     },
     async jwt({ token, account }) {
       if (account) {
+        const {
+          data: { accessToken },
+        } = await applicantApiService.signIn({ googleIdToken: account.id_token! });
         // eslint-disable-next-line no-param-reassign
-        token.googleIdToken = account.id_token;
+        token.accessToken = accessToken;
       }
       return token;
     },


### PR DESCRIPTION
## 변경사항

- [링크](https://next-auth.js.org/configuration/callbacks#jwt-callback)에 따르면 persist한 데이터는 jwt 콜백에서 처리하는 것이 맞다고 명시되어 있습니다.
- 따라서 각 session 콜백 내에서 API 콜을 호출하는 대신 jwt 콜백 내에서 accessToken을 획득 후 token 객체에 할당해 둔 후 session 객체가 이 accessToken을 merge하여 반환하는 형태로 수정해주었습니다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
