### PR TITLE
지원서 상세 페이지

### DIFF
--- a/pages/apply/[platformName].tsx
+++ b/pages/apply/[platformName].tsx
@@ -3,7 +3,8 @@ import { ApplyLayout, ConfirmModalDialog } from '@/components';
 import {
   PlatformHeadings,
   PLATFORM_HEADINGS,
-} from '@/components/apply/ApplyForm/ApplyForm.component';
+  PLATFORM_ROLE,
+} from '@/components/apply/ApplyLayout/ApplyLayout.component';
 import { teamIds, teamNames, Teams } from '@/constants';
 import { usePreventPageChange } from '@/hooks';
 import { Application } from '@/types/dto';
@@ -34,6 +35,7 @@ const Apply = ({ application }: ApplyProps) => {
     <>
       <ApplyLayout
         heading={PLATFORM_HEADINGS[router.asPath as keyof PlatformHeadings]}
+        role={PLATFORM_ROLE[router.asPath as keyof PlatformHeadings]}
         application={application}
         isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
         setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}

--- a/pages/my-page/application-detail/[applicationId].tsx
+++ b/pages/my-page/application-detail/[applicationId].tsx
@@ -1,0 +1,81 @@
+import { applicationApiService } from '@/api/services';
+import { ConfirmModalDialog, ApplicationDetailLayout } from '@/components';
+import { usePreventPageChange } from '@/hooks';
+import { Application } from '@/types/dto';
+import { GetServerSideProps } from 'next';
+import { getSession } from 'next-auth/react';
+import { useState } from 'react';
+
+interface ApplicationDetailProps {
+  application: Application;
+}
+
+const ApplicationDetail = ({ application }: ApplicationDetailProps) => {
+  const [isOpenConfirmModal, setIsOpenConfirmModal] = useState(false);
+  const [isOpenSuccessSubmitedModal, setIsOpenSuccessSubmitedModal] = useState(false);
+
+  const { handleMoveAfterBlocking } = usePreventPageChange(setIsOpenConfirmModal, [
+    isOpenConfirmModal,
+    isOpenSuccessSubmitedModal,
+  ]);
+
+  const handleCloseConfirmModal = () => {
+    setIsOpenConfirmModal(false);
+  };
+
+  return (
+    <>
+      <ApplicationDetailLayout
+        application={application}
+        isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
+        setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+      />
+      {isOpenConfirmModal && (
+        <ConfirmModalDialog
+          approvalButtonMessage="나가기"
+          cancelButtonMessage="머물기"
+          handleApprovalButton={handleMoveAfterBlocking}
+          handleCancelButton={handleCloseConfirmModal}
+          heading="지금..나가시게요..?"
+          paragraph="저장 안된 내용은..날아갈 수 있다능.."
+          setIsOpenModal={setIsOpenConfirmModal}
+        />
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context);
+
+  if (!session) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+  }
+
+  const applicationRes = await applicationApiService.getApplicationDetail({
+    accessToken: session.accessToken,
+    applicationId: parseInt(context.params?.applicationId as string, 10),
+  });
+
+  // TODO:(하준) API 실패 응답시 띄워 줄 UI나 동작이 정의되면 변경
+  if (applicationRes.code !== 'SUCCESS')
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+
+  return {
+    props: {
+      application: applicationRes?.data,
+    },
+  };
+};
+
+export default ApplicationDetail;

--- a/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
+++ b/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
@@ -1,0 +1,57 @@
+import { ApplyForm } from '@/components';
+import { Application, TeamName } from '@/types/dto';
+import { Dispatch, SetStateAction } from 'react';
+import * as Styled from './ApplicationDetailLayout.styled';
+
+export const PLATFORM_HEADINGS: Record<TeamName, string> = {
+  Design: 'Product Design Team',
+  Android: 'Android Team',
+  iOS: 'iOS Team',
+  Web: 'Web Team',
+  Node: 'Node Team',
+  Spring: 'Spring Team',
+} as const;
+
+export const PLATFORM_ROLE: Record<TeamName, string> = {
+  Web: 'Frontend Developer',
+  Android: 'Android Developer',
+  Design: 'Product Designer',
+  iOS: 'iOS Developer',
+  Node: 'Backend Developer',
+  Spring: 'Backend Developer',
+} as const;
+
+interface ApplicationDetailLayoutProps {
+  application: Application;
+  isOpenSuccessSubmitedModal: boolean;
+  setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
+}
+
+const ApplicationDetailLayout = ({
+  application,
+  isOpenSuccessSubmitedModal,
+  setIsOpenSuccessSubmitedModal,
+}: ApplicationDetailLayoutProps) => {
+  return (
+    <section>
+      <Styled.ApplicationDetailHeadingWrapper>
+        <Styled.ApplicationDetailHeadingInner>
+          <Styled.ApplicationDetailHeading>지원서 상세</Styled.ApplicationDetailHeading>
+          <Styled.PlatformHeading>
+            {PLATFORM_HEADINGS[application.team.name]}
+          </Styled.PlatformHeading>
+          <Styled.PlatformRole>{PLATFORM_ROLE[application.team.name]}</Styled.PlatformRole>
+        </Styled.ApplicationDetailHeadingInner>
+      </Styled.ApplicationDetailHeadingWrapper>
+      <Styled.Layout>
+        <ApplyForm
+          application={application}
+          isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
+          setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+        />
+      </Styled.Layout>
+    </section>
+  );
+};
+
+export default ApplicationDetailLayout;

--- a/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.styled.ts
+++ b/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.styled.ts
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ApplicationDetailHeadingWrapper = styled.div`
+  ${({ theme }) => css`
+    background: ${theme.colors.purple20};
+  `}
+`;
+
+export const ApplicationDetailHeadingInner = styled.div`
+  ${({ theme }) => css`
+    width: 100%;
+    max-width: 82.4rem;
+    margin: 0 auto;
+    padding: 5rem 2rem 3rem;
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      padding: 3.6rem 2rem 2rem;
+    }
+  `}
+`;
+
+export const ApplicationDetailHeading = styled.h2`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold46};
+    margin-bottom: 2rem;
+    color: ${theme.colors.gray80};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold24};
+    }
+  `}
+`;
+
+export const PlatformHeading = styled.h3`
+  ${({ theme }) => css`
+    ${theme.fonts.en.extrabold24};
+    color: ${theme.colors.gray80};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.en.extrabold18}
+      margin-bottom: 0.8rem;
+    }
+  `}
+`;
+
+export const PlatformRole = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.en.extrabold18};
+    color: ${theme.colors.gray80};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.en.extrabold15};
+    }
+  `}
+`;
+
+export const Layout = styled.div`
+  ${({ theme }) => css`
+    width: 100%;
+    max-width: 82.4rem;
+    margin: 0 auto;
+    padding: 0rem 2rem 12.9rem;
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      padding: 3.6rem 2rem 9.9rem;
+    }
+  `}
+`;

--- a/src/components/applicationDetail/index.ts
+++ b/src/components/applicationDetail/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplicationDetailLayout } from './ApplicationDetailLayout/ApplicationDetailLayout.component';

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -6,15 +6,7 @@ import {
   LabeledInput,
   LabeledTextArea,
 } from '@/components';
-import {
-  APPLY_ANDROID_PAGE,
-  APPLY_DESIGN_PAGE,
-  APPLY_FRONT_END_PAGE,
-  APPLY_IOS_PAGE,
-  APPLY_NODE_PAGE,
-  APPLY_SPRING_PAGE,
-  HOME_PAGE,
-} from '@/constants';
+import { HOME_PAGE, MY_PAGE_APPLICATON_DETAIL } from '@/constants';
 import { ValueOf } from '@/types';
 import { Application } from '@/types/dto';
 import { useSession } from 'next-auth/react';
@@ -32,7 +24,6 @@ import { FieldValues, useForm } from 'react-hook-form';
 import * as Styled from './ApplyForm.styled';
 
 interface ApplyFormProps {
-  heading: string;
   application: Application;
   isOpenSuccessSubmitedModal: boolean;
   setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
@@ -52,19 +43,7 @@ const APPLY_FORM_KEYS = {
   isAgreePersonalInfo: 'isAgreePersonalInfo',
 } as const;
 
-export const PLATFORM_HEADINGS = {
-  [APPLY_FRONT_END_PAGE]: 'Frontend Developer',
-  [APPLY_ANDROID_PAGE]: 'Android Developer',
-  [APPLY_DESIGN_PAGE]: 'Product Design',
-  [APPLY_IOS_PAGE]: 'iOS Developer',
-  [APPLY_NODE_PAGE]: 'Server Developer (Node.js)',
-  [APPLY_SPRING_PAGE]: 'Server Developer (Spring)',
-} as const;
-
-export type PlatformHeadings = typeof PLATFORM_HEADINGS;
-
 const ApplyForm = ({
-  heading,
   application,
   isOpenSuccessSubmitedModal,
   setIsOpenSuccessSubmitedModal,
@@ -194,8 +173,7 @@ const ApplyForm = ({
   };
 
   return (
-    <section>
-      <Styled.PlatformHeading>{heading}</Styled.PlatformHeading>
+    <>
       <form onSubmit={handleSubmit(handleOpenSubmitModal)}>
         <Styled.PersonalInformationSection>
           <Styled.SectionHeading>개인 정보</Styled.SectionHeading>
@@ -249,7 +227,6 @@ const ApplyForm = ({
           <Styled.PersonalInformationWrapper>
             <LabeledInput
               id={APPLY_FORM_KEYS.email}
-              // TODO:(하준) 유저의 이메일로 value 삽입
               value={session.data?.user?.email || ''}
               disabled
               label="이메일"
@@ -405,8 +382,10 @@ const ApplyForm = ({
           cancelButtonMessage="홈으로"
           setIsOpenModal={setIsOpenSuccessSubmitedModal}
           handleCancelButton={() => router.push(HOME_PAGE)}
-          // TODO:(하준) 마이페이지 생성 및 상수 정의되면 수정
-          handleApprovalButton={() => router.push('/')}
+          handleApprovalButton={() => {
+            router.push(`${MY_PAGE_APPLICATON_DETAIL}/${application.applicationId}`);
+            setIsOpenSuccessSubmitedModal(false);
+          }}
           escClose={false}
           deemClose={false}
         />
@@ -422,7 +401,7 @@ const ApplyForm = ({
           deemClose={false}
         />
       )}
-    </section>
+    </>
   );
 };
 

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -2,17 +2,6 @@ import LinkTo from '@/components/common/LinkTo/LinkTo.component';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const PlatformHeading = styled.h3`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.bold46};
-    color: ${theme.colors.gray80};
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      ${theme.fonts.kr.bold24}
-    }
-  `}
-`;
-
 export const PersonalInformationSection = styled.section`
   margin-top: 6rem;
 `;

--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -1,10 +1,39 @@
 import { ApplyForm } from '@/components';
+import {
+  APPLY_ANDROID_PAGE,
+  APPLY_DESIGN_PAGE,
+  APPLY_FRONT_END_PAGE,
+  APPLY_IOS_PAGE,
+  APPLY_NODE_PAGE,
+  APPLY_SPRING_PAGE,
+} from '@/constants';
 import { Application } from '@/types/dto';
 import { Dispatch, SetStateAction } from 'react';
 import * as Styled from './ApplyLayout.styled';
 
+export const PLATFORM_HEADINGS = {
+  [APPLY_FRONT_END_PAGE]: 'Web Team',
+  [APPLY_ANDROID_PAGE]: 'Android Team',
+  [APPLY_DESIGN_PAGE]: 'Product Design Team',
+  [APPLY_IOS_PAGE]: 'iOS Team',
+  [APPLY_NODE_PAGE]: 'Node Team',
+  [APPLY_SPRING_PAGE]: 'Spring Team',
+} as const;
+
+export const PLATFORM_ROLE = {
+  [APPLY_FRONT_END_PAGE]: 'Frontend Developer',
+  [APPLY_ANDROID_PAGE]: 'Android Developer',
+  [APPLY_DESIGN_PAGE]: 'Product Designer',
+  [APPLY_IOS_PAGE]: 'iOS Developer',
+  [APPLY_NODE_PAGE]: 'Backend Developer',
+  [APPLY_SPRING_PAGE]: 'Backend Developer',
+} as const;
+
+export type PlatformHeadings = typeof PLATFORM_HEADINGS;
+
 interface ApplyLayoutProps {
   heading: string;
+  role: string;
   application: Application;
   isOpenSuccessSubmitedModal: boolean;
   setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
@@ -12,6 +41,7 @@ interface ApplyLayoutProps {
 
 const ApplyLayout = ({
   heading,
+  role,
   application,
   isOpenSuccessSubmitedModal,
   setIsOpenSuccessSubmitedModal,
@@ -19,12 +49,15 @@ const ApplyLayout = ({
   return (
     <Styled.Layout>
       <Styled.ApplyHeading>지원서 작성</Styled.ApplyHeading>
-      <ApplyForm
-        heading={heading}
-        application={application}
-        isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-        setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
-      />
+      <section>
+        <Styled.PlatformHeading>{heading}</Styled.PlatformHeading>
+        <Styled.PlatformRole>{role}</Styled.PlatformRole>
+        <ApplyForm
+          application={application}
+          isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
+          setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+        />
+      </section>
     </Styled.Layout>
   );
 };

--- a/src/components/apply/ApplyLayout/ApplyLayout.styled.ts
+++ b/src/components/apply/ApplyLayout/ApplyLayout.styled.ts
@@ -19,3 +19,25 @@ export const ApplyHeading = styled.h2`
     ${theme.a11y.visuallyHidden};
   `}
 `;
+
+export const PlatformHeading = styled.h3`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold46};
+    color: ${theme.colors.gray80};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold24}
+    }
+  `}
+`;
+
+export const PlatformRole = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold22};
+    color: ${theme.colors.gray80};
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold16}
+    }
+  `}
+`;

--- a/src/components/applyStatus/StatusList/StatusList.component.tsx
+++ b/src/components/applyStatus/StatusList/StatusList.component.tsx
@@ -1,3 +1,4 @@
+import { MY_PAGE_APPLICATON_DETAIL } from '@/constants';
 import { useDetectViewPort } from '@/hooks';
 import { Application, ApplicationAuditStatus, TeamName } from '@/types/dto';
 import * as Styled from './StatusList.styled';
@@ -54,7 +55,9 @@ const StatusList = ({ applications }: StatusListProps) => {
                         <Styled.StatusText>{TEAM__NICK_NAME[team.name]}</Styled.StatusText>
                         <Styled.StatusText>{STATUS_WORDS[result.status]}</Styled.StatusText>
                         <Styled.DetailLinkWrapper>
-                          <Styled.ApplicationDetailLink href="/">
+                          <Styled.ApplicationDetailLink
+                            href={`${MY_PAGE_APPLICATON_DETAIL}/${applicationId}`}
+                          >
                             상세보기
                           </Styled.ApplicationDetailLink>
                         </Styled.DetailLinkWrapper>
@@ -93,7 +96,9 @@ const StatusList = ({ applications }: StatusListProps) => {
                           <Styled.StatusText>{STATUS_WORDS[result.status]}</Styled.StatusText>
                         </Styled.ListItemWrapper>
                         <Styled.DetailLinkWrapper>
-                          <Styled.ApplicationDetailLink href="/">
+                          <Styled.ApplicationDetailLink
+                            href={`${MY_PAGE_APPLICATON_DETAIL}/${applicationId}`}
+                          >
                             지원서 상세보기
                           </Styled.ApplicationDetailLink>
                         </Styled.DetailLinkWrapper>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export * from './home';
 export * from './faq';
 export * from './account';
 export * from './applyStatus';
+export * from './applicationDetail';

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -19,3 +19,4 @@ export const FAQ_ANDROID_PAGE = '/faq/android';
 
 export const MY_PAGE_ACCOUNT = '/my-page/account';
 export const MY_PAGE_APPLY_STATUS = '/my-page/apply-status';
+export const MY_PAGE_APPLICATON_DETAIL = '/my-page/application-detail'; // 사용시 `/${id}` 넣어줄것 (동적 라우트)

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { theme } from '@/styles/themes';
 
 export const resetCss = css`
   html {
@@ -132,12 +133,10 @@ export const resetCss = css`
   }
 
   body {
-    /* TODO:(하준) 기본 Font Color 나오면 변경 */
-    color: #000;
+    color: ${theme.colors.gray80};
     font-family: SpoqaHanSansNeo, sans-serif;
     line-height: 1;
-    /* TODO:(하준) 기본 BackgroundColor 나오면 변경 */
-    background-color: #fff;
+    background-color: ${theme.colors.white};
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -152,8 +151,7 @@ export const resetCss = css`
   }
 
   a {
-    /* TODO:(하준) 기본 A tag Color 혹은 Font Color 나오면 변경 */
-    color: #000;
+    color: ${theme.colors.gray80};
     text-decoration: none;
   }
 


### PR DESCRIPTION
## 변경사항

- 애플리케이션의 폰트와 백그라운드의 기본 색상을 reset css에 적용해주었습니다.
- 지원서 상세 페이지의 라우트를 상수로 정의하였습니다.
- 지원하기 페이지 헤딩 부분의 디자인 변경사항을 적용시켜주었습니다.
- 지원하기 페이지에서 사용되는 상수들의 위치가 어색한곳이 있는것 같아 일부 이동시켜주었습니다. 만나서 작업할때 공통된 상수들을 한번 정리하면 좋을것 같습니다.
- 지원서 상세 페이지를 구현하였습니다. 이 페이지로 와야하는 Link들에 href를 추가해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
