### PR TITLE
헤더 디자인 변경사항 적용

### DIFF
--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -1,26 +1,17 @@
 import { LinkTo, MainNavigation } from '@/components';
 import { HOME_PAGE, VIEWPORT_SIZE } from '@/constants';
-import { useDetectViewPort, useWatchingIsScrollTop } from '@/hooks';
+import { useDetectViewPort } from '@/hooks';
 import MashUpLogo24 from '@/assets/svg/mash-up-logo-24.svg';
 import MashUpLogo33 from '@/assets/svg/mash-up-logo-33.svg';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 import * as Styled from './Header.styled';
 
 const Header = () => {
-  const [isHome, setIsHome] = useState(false);
   const { size } = useDetectViewPort();
   const { asPath } = useRouter();
 
-  useEffect(() => {
-    if (asPath === HOME_PAGE) setIsHome(true);
-    else setIsHome(false);
-  }, [asPath]);
-
-  const isScrollTop = useWatchingIsScrollTop();
-
   return (
-    <Styled.Header isScrollTop={isScrollTop} currentPage={asPath} isHome={isHome}>
+    <Styled.Header currentPage={asPath}>
       <Styled.HeaderInner>
         <LinkTo href={HOME_PAGE}>
           <Styled.Heading currentPage={asPath} aria-label="Mash Up Recruit">

--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -23,11 +23,7 @@ const Header = () => {
     <Styled.Header isScrollTop={isScrollTop} currentPage={asPath} isHome={isHome}>
       <Styled.HeaderInner>
         <LinkTo href={HOME_PAGE}>
-          <Styled.Heading
-            isScrollTop={isScrollTop}
-            currentPage={asPath}
-            aria-label="Mash Up Recruit"
-          >
+          <Styled.Heading currentPage={asPath} aria-label="Mash Up Recruit">
             {size === VIEWPORT_SIZE.MOBILE ? <MashUpLogo24 /> : <MashUpLogo33 />}
             <span>Mash-Up Recruit</span>
           </Styled.Heading>

--- a/src/components/common/Header/Header.styled.ts
+++ b/src/components/common/Header/Header.styled.ts
@@ -3,28 +3,18 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface HeaderProps {
-  isScrollTop: boolean;
   currentPage: string;
-  isHome: boolean;
 }
 
 export const Header = styled.header<HeaderProps>`
-  ${({ theme, isScrollTop, currentPage, isHome }) => css`
+  ${({ theme, currentPage }) => css`
     position: fixed;
     z-index: ${theme.zIndex.header};
     width: 100%;
     height: 8rem;
     padding: 1.7rem 0;
+    background: ${currentPage === HOME_PAGE ? 'rgba(18, 19, 20, 0.8)' : 'rgba(255, 255, 255, 0.8)'};
     backdrop-filter: blur(2rem);
-    ${currentPage === HOME_PAGE
-      ? css`
-          background: ${isScrollTop ? css`rgba(18, 19, 20, 0.8)` : theme.colors.gray95};
-        `
-      : css`
-          background: rgba(255, 255, 255, 0.8);
-        `};
-
-    transition: ${isHome ? '0.5s' : 0};
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       height: 6rem;

--- a/src/components/common/Header/Header.styled.ts
+++ b/src/components/common/Header/Header.styled.ts
@@ -15,13 +15,13 @@ export const Header = styled.header<HeaderProps>`
     width: 100%;
     height: 8rem;
     padding: 1.7rem 0;
-    ${isScrollTop && currentPage === HOME_PAGE
+    backdrop-filter: blur(2rem);
+    ${currentPage === HOME_PAGE
       ? css`
-          background: ${theme.colors.black};
+          background: ${isScrollTop ? css`rgba(18, 19, 20, 0.8)` : theme.colors.gray95};
         `
       : css`
-          background: rgba(255, 255, 255, 0.7);
-          backdrop-filter: blur(2rem);
+          background: rgba(255, 255, 255, 0.8);
         `};
 
     transition: ${isHome ? '0.5s' : 0};
@@ -42,12 +42,11 @@ export const HeaderInner = styled.div`
 `;
 
 interface HeadingProps {
-  isScrollTop: boolean;
   currentPage: string;
 }
 
 export const Heading = styled.h1<HeadingProps>`
-  ${({ theme, isScrollTop, currentPage }) => css`
+  ${({ theme, currentPage }) => css`
     display: inline-block;
     width: 24rem;
     padding: 0.7rem 0 0 0.6rem;
@@ -55,7 +54,7 @@ export const Heading = styled.h1<HeadingProps>`
     span {
       ${theme.fonts.en.extrabold24}
       margin-left: 1.3rem;
-      color: ${isScrollTop && currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray90};
+      color: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray90};
     }
 
     @media (max-width: ${theme.breakPoint.media.tabletS}) {

--- a/src/components/common/MainNavigation/MainNavigation.component.tsx
+++ b/src/components/common/MainNavigation/MainNavigation.component.tsx
@@ -2,7 +2,7 @@ import { FAQ_COMMON_PAGE, HOME_PAGE, VIEWPORT_SIZE } from '@/constants';
 import { LinkTo, SignInModalDialog, MyPageTab } from '@/components';
 import DivisionLine from '@/assets/svg/division-line.svg';
 import { MouseEventHandler, MutableRefObject, useEffect, useRef, useState } from 'react';
-import { useDetectOutsideClick, useDetectViewPort, useWatchingIsScrollTop } from '@/hooks';
+import { useDetectOutsideClick, useDetectViewPort } from '@/hooks';
 import Router, { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import ChevronBottom12 from '@/assets/svg/chevron-bottom-12.svg';
@@ -11,7 +11,6 @@ import * as Styled from './MainNavigation.styled';
 const MainNavigation = () => {
   const session = useSession();
   const { size } = useDetectViewPort();
-  const isScrollTop = useWatchingIsScrollTop();
   const { asPath } = useRouter();
 
   const [isOpenSignInModal, setIsOpenSignInModal] = useState(false);
@@ -45,7 +44,7 @@ const MainNavigation = () => {
   return (
     <>
       <Styled.Nav>
-        <Styled.NavList isScrollTop={isScrollTop} currentPage={asPath}>
+        <Styled.NavList currentPage={asPath}>
           <li>
             <LinkTo href={HOME_PAGE}>모집 공고</LinkTo>
           </li>
@@ -58,7 +57,6 @@ const MainNavigation = () => {
               <div ref={MyPageTabWrrpaer}>
                 <Styled.MyPageButton
                   type="button"
-                  isScrollTop={isScrollTop}
                   currentPage={asPath}
                   onClick={handleToggleMyPageTab}
                   isOpenMyPageTab={isOpenMyPageTab}
@@ -74,7 +72,6 @@ const MainNavigation = () => {
             ) : (
               <Styled.SignInButton
                 type="button"
-                isScrollTop={isScrollTop}
                 currentPage={asPath}
                 onClick={handleOpenSignInModal}
                 ref={loginButtonRef}

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -73,15 +73,14 @@ export const NavList = styled.ul<NavListProps>`
 `;
 
 interface SignInButtonProps {
-  isScrollTop: boolean;
   currentPage: string;
 }
 
 export const SignInButton = styled.button<SignInButtonProps>`
-  ${({ theme, isScrollTop, currentPage }) => css`
+  ${({ theme, currentPage }) => css`
     ${theme.fonts.kr.bold18}
     padding: 0;
-    color: ${isScrollTop && currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
+    color: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
     background: transparent;
     border: 0;
 

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -8,12 +8,11 @@ export const Nav = styled.nav`
 `;
 
 interface NavListProps {
-  isScrollTop: boolean;
   currentPage: string;
 }
 
 export const NavList = styled.ul<NavListProps>`
-  ${({ theme, isScrollTop, currentPage }) => css`
+  ${({ theme, currentPage }) => css`
     display: flex;
     align-items: center;
     height: 2.7rem;
@@ -39,9 +38,7 @@ export const NavList = styled.ul<NavListProps>`
       }
 
       & > a {
-        color: ${isScrollTop && currentPage === HOME_PAGE
-          ? theme.colors.white
-          : theme.colors.gray80};
+        color: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
       }
 
       & > a:hover {
@@ -98,16 +95,15 @@ export const SignInButton = styled.button<SignInButtonProps>`
 `;
 
 interface MyPageButtonProps {
-  isScrollTop: boolean;
   currentPage: string;
   isOpenMyPageTab: boolean;
 }
 
 export const MyPageButton = styled.button<MyPageButtonProps>`
-  ${({ theme, isScrollTop, currentPage, isOpenMyPageTab }) => css`
+  ${({ theme, currentPage, isOpenMyPageTab }) => css`
     ${theme.fonts.kr.bold18}
     padding: 0;
-    color: ${isScrollTop && currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
+    color: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
     background: transparent;
     border: 0;
 
@@ -133,9 +129,7 @@ export const MyPageButton = styled.button<MyPageButtonProps>`
           `};
 
       & > path {
-        stroke: ${isScrollTop && currentPage === HOME_PAGE
-          ? theme.colors.white
-          : theme.colors.gray80};
+        stroke: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
       }
     }
   `}

--- a/src/components/common/MyPageTab/MyPageTab.component.tsx
+++ b/src/components/common/MyPageTab/MyPageTab.component.tsx
@@ -50,7 +50,7 @@ const MyPageTab = ({ isOpenMyPageTab, setIsOpenMyPageTab }: MyPageTabProps) => {
   }, [isOpenMyPageTab, session.status]);
 
   return (
-    <Styled.MyPageTabPanel ref={myPageTabPanelRef} aria-hidden={isOpenMyPageTab}>
+    <Styled.MyPageTabPanel ref={myPageTabPanelRef} aria-hidden={!isOpenMyPageTab}>
       <Styled.MyPageTabContent ref={myPageTabContentRef}>
         <Styled.UserName>{session?.data?.user?.name}님</Styled.UserName>
         <Styled.UserEmail>{session?.data?.user?.email}asfasdfa</Styled.UserEmail>

--- a/src/components/common/MyPageTab/MyPageTab.component.tsx
+++ b/src/components/common/MyPageTab/MyPageTab.component.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import ChevronRight7 from '@/assets/svg/chevron-right-7.svg';
 import { MY_PAGE_ACCOUNT, MY_PAGE_APPLY_STATUS } from '@/constants';
+import { useRouter } from 'next/router';
 import * as Styled from './MyPageTab.styled';
 
 interface MyPageTabProps {
@@ -20,6 +21,8 @@ const MyPageTab = ({ isOpenMyPageTab, setIsOpenMyPageTab }: MyPageTabProps) => {
   const session = useSession();
   const myPageTabPanelRef = useRef<HTMLDivElement>(null);
   const myPageTabContentRef = useRef<HTMLDivElement>(null);
+
+  const { asPath: currentPage } = useRouter();
 
   const handleSignOut: MouseEventHandler<HTMLButtonElement> = () => {
     signOut();
@@ -51,19 +54,26 @@ const MyPageTab = ({ isOpenMyPageTab, setIsOpenMyPageTab }: MyPageTabProps) => {
 
   return (
     <Styled.MyPageTabPanel ref={myPageTabPanelRef} aria-hidden={!isOpenMyPageTab}>
-      <Styled.MyPageTabContent ref={myPageTabContentRef}>
-        <Styled.UserName>{session?.data?.user?.name}님</Styled.UserName>
-        <Styled.UserEmail>{session?.data?.user?.email}asfasdfa</Styled.UserEmail>
+      <Styled.MyPageTabContent ref={myPageTabContentRef} currentPage={currentPage}>
+        <Styled.UserName currentPage={currentPage}>{session?.data?.user?.name}님</Styled.UserName>
+        <Styled.UserEmail currentPage={currentPage}>
+          {session?.data?.user?.email}asfasdfa
+        </Styled.UserEmail>
 
         <Styled.TabLink
           href={MY_PAGE_ACCOUNT}
           onKeyDown={handleShiftTabCloseTab}
           tabIndex={isOpenMyPageTab ? 0 : -1}
+          currentPage={currentPage}
         >
           계정 관리
           <ChevronRight7 />
         </Styled.TabLink>
-        <Styled.TabLink href={MY_PAGE_APPLY_STATUS} tabIndex={isOpenMyPageTab ? 0 : -1}>
+        <Styled.TabLink
+          href={MY_PAGE_APPLY_STATUS}
+          tabIndex={isOpenMyPageTab ? 0 : -1}
+          currentPage={currentPage}
+        >
           지원 내역
           <ChevronRight7 />
         </Styled.TabLink>
@@ -71,6 +81,7 @@ const MyPageTab = ({ isOpenMyPageTab, setIsOpenMyPageTab }: MyPageTabProps) => {
           onClick={handleSignOut}
           onKeyDown={handleTabCloseTab}
           tabIndex={isOpenMyPageTab ? 0 : -1}
+          currentPage={currentPage}
         >
           로그아웃
         </Styled.SignOutButton>

--- a/src/components/common/MyPageTab/MyPageTab.styled.ts
+++ b/src/components/common/MyPageTab/MyPageTab.styled.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import LinkTo from '@/components/common/LinkTo/LinkTo.component';
+import { HOME_PAGE } from '@/constants';
 
 export const MyPageTabPanel = styled.div`
   position: absolute;
@@ -12,73 +13,108 @@ export const MyPageTabPanel = styled.div`
   transition: 0.5s;
 `;
 
-export const MyPageTabContent = styled.div`
-  ${({ theme }) =>
-    css`
+interface MyPageTabContentProps {
+  currentPage: string;
+}
+
+export const MyPageTabContent = styled.div<MyPageTabContentProps>`
+  ${({ theme, currentPage }) => {
+    const isHomePage = currentPage === HOME_PAGE;
+    return css`
       width: 19.2rem;
       padding: 2.4rem 1.2rem 1.2rem;
-      background: ${theme.colors.white};
-      border: 0.1rem solid ${theme.colors.gray20};
+      background: ${isHomePage ? theme.colors.gray90 : theme.colors.white};
+      border: 0.1rem solid ${isHomePage ? theme.colors.gray80 : theme.colors.gray20};
       border-radius: 1.6rem;
-    `}
+    `;
+  }}
 `;
 
-export const UserName = styled.span`
-  ${({ theme }) => css`
+interface UserNameProps {
+  currentPage: string;
+}
+
+export const UserName = styled.span<UserNameProps>`
+  ${({ theme, currentPage }) => css`
     ${theme.fonts.kr.bold18};
     padding-left: 1.2rem;
+    color: ${currentPage === HOME_PAGE ? theme.colors.gray10 : theme.colors.gray80};
   `}
 `;
 
-export const UserEmail = styled.span`
-  ${({ theme }) => css`
+interface UserEmailProps {
+  currentPage: string;
+}
+
+export const UserEmail = styled.span<UserEmailProps>`
+  ${({ theme, currentPage }) => css`
     ${theme.fonts.kr.medium13};
     display: block;
     width: 16.8rem;
     margin: 0.2rem 0 1rem;
     padding-left: 1.2rem;
     overflow: hidden;
-    color: ${theme.colors.gray50};
+    color: ${currentPage === HOME_PAGE ? theme.colors.gray60 : theme.colors.gray50};
     white-space: nowrap;
     text-overflow: ellipsis;
   `}
 `;
 
-export const TabLink = styled(LinkTo)`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.medium14};
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem 1.2rem;
-    color: ${theme.colors.gray80};
-    background: ${theme.colors.white};
-    border: 0;
-    border-radius: 1.2rem;
+interface TabLinkProps {
+  currentPage: string;
+}
 
-    &:hover {
-      background: ${theme.colors.gray10};
-    }
-  `}
+export const TabLink = styled(LinkTo)<TabLinkProps>`
+  ${({ theme, currentPage }) => {
+    const isHomePage = currentPage === HOME_PAGE;
+
+    return css`
+      ${theme.fonts.kr.medium14};
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.2rem;
+      color: ${isHomePage ? theme.colors.gray10 : theme.colors.gray80};
+      background: ${isHomePage ? theme.colors.gray90 : theme.colors.white};
+      border: 0;
+      border-radius: 1.2rem;
+
+      &:hover {
+        background: ${isHomePage ? theme.colors.gray80 : theme.colors.gray10};
+      }
+
+      & > svg > path {
+        stroke: ${isHomePage ? theme.colors.gray10 : theme.colors.gray80};
+      }
+    `;
+  }}
 `;
 
-export const SignOutButton = styled.button`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.medium14};
-    width: 100%;
-    padding: 1rem 0.6rem 1rem 1.2rem;
-    color: ${theme.colors.gray50};
-    text-align: start;
-    background: ${theme.colors.white};
-    border: 0;
-    border-radius: 1.2rem;
+interface SignOutButtonProps {
+  currentPage: string;
+}
 
-    & > svg {
-      margin-left: 9.5rem;
-    }
+export const SignOutButton = styled.button<SignOutButtonProps>`
+  ${({ theme, currentPage }) => {
+    const isHomePage = currentPage === HOME_PAGE;
 
-    &:hover {
-      background: ${theme.colors.gray10};
-    }
-  `}
+    return css`
+      ${theme.fonts.kr.medium14};
+      width: 100%;
+      padding: 1rem 0.6rem 1rem 1.2rem;
+      color: ${isHomePage ? theme.colors.gray10 : theme.colors.gray50};
+      text-align: start;
+      background: ${isHomePage ? theme.colors.gray90 : theme.colors.white};
+      border: 0;
+      border-radius: 1.2rem;
+
+      & > svg {
+        margin-left: 9.5rem;
+      }
+
+      &:hover {
+        background: ${isHomePage ? theme.colors.gray80 : theme.colors.gray10};
+      }
+    `;
+  }}
 `;

--- a/src/components/common/MyPageTab/MyPageTab.styled.ts
+++ b/src/components/common/MyPageTab/MyPageTab.styled.ts
@@ -15,7 +15,8 @@ export const MyPageTabPanel = styled.div`
 export const MyPageTabContent = styled.div`
   ${({ theme }) =>
     css`
-      padding: 2.8rem 1.6rem 1.4rem 1.2rem;
+      width: 19.2rem;
+      padding: 2.4rem 1.2rem 1.2rem;
       background: ${theme.colors.white};
       border: 0.1rem solid ${theme.colors.gray20};
       border-radius: 1.6rem;
@@ -46,16 +47,14 @@ export const UserEmail = styled.span`
 export const TabLink = styled(LinkTo)`
   ${({ theme }) => css`
     ${theme.fonts.kr.medium14};
-    display: block;
-    padding: 1rem 0.6rem 1rem 1.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.2rem;
     color: ${theme.colors.gray80};
     background: ${theme.colors.white};
     border: 0;
     border-radius: 1.2rem;
-
-    & > svg {
-      margin-left: 9.5rem;
-    }
 
     &:hover {
       background: ${theme.colors.gray10};

--- a/src/styles/themes/colors.ts
+++ b/src/styles/themes/colors.ts
@@ -11,6 +11,7 @@ export const colors = {
   gray70: '#495057',
   gray80: '#343A40',
   gray90: '#212529',
+  gray95: '#121314',
   purple80: '#4127D1',
   purple70: '#6244FF',
   purple60: '#836BFF',


### PR DESCRIPTION
## 변경사항

- 홈페이지에서 스크롤을 내려도 헤더 백그라운드가 `rgba(18, 19, 20, 0.8), background-filter: blur(20px)`로 유지되게끔 변경해주었습니다.
이에 따라서 헤더 내부의 글씨 색상도 대비되게 변경해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
