### PR TITLE
지원하기 페이지 임시저장시, 제출했을시에 각각의 페이지에서 UI변경, 제출 막는처리 등 조건처리

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
     "import/no-unresolved": 0,
     "import/no-cycle": 0,
     "react/require-default-props": 0,
-    "no-throw-literal": 0
+    "no-throw-literal": 0,
+    "no-nested-ternary": 0
   },
   "overrides": [
     {

--- a/pages/apply/[platformName].tsx
+++ b/pages/apply/[platformName].tsx
@@ -1,17 +1,15 @@
 import { applicationApiService } from '@/api/services';
-import { ApplyLayout, ConfirmModalDialog } from '@/components';
+import { ApplyLayout } from '@/components';
 import {
   PlatformHeadings,
   PLATFORM_HEADINGS,
   PLATFORM_ROLE,
 } from '@/components/apply/ApplyLayout/ApplyLayout.component';
 import { teamIds, teamNames, Teams } from '@/constants';
-import { usePreventPageChange } from '@/hooks';
 import { Application } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 
 interface ApplyProps {
   application: Application;
@@ -20,40 +18,14 @@ interface ApplyProps {
 
 const Apply = ({ application, isSubmited }: ApplyProps) => {
   const router = useRouter();
-  const [isOpenConfirmModal, setIsOpenConfirmModal] = useState(false);
-  const [isOpenSuccessSubmitedModal, setIsOpenSuccessSubmitedModal] = useState(false);
-
-  const { handleMoveAfterBlocking } = usePreventPageChange(setIsOpenConfirmModal, [
-    isOpenConfirmModal,
-    isOpenSuccessSubmitedModal,
-  ]);
-
-  const handleCloseConfirmModal = () => {
-    setIsOpenConfirmModal(false);
-  };
 
   return (
-    <>
-      <ApplyLayout
-        heading={PLATFORM_HEADINGS[router.asPath as keyof PlatformHeadings]}
-        role={PLATFORM_ROLE[router.asPath as keyof PlatformHeadings]}
-        application={application}
-        isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-        setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
-        isSubmited={isSubmited}
-      />
-      {isOpenConfirmModal && (
-        <ConfirmModalDialog
-          approvalButtonMessage="나가기"
-          cancelButtonMessage="머물기"
-          handleApprovalButton={handleMoveAfterBlocking}
-          handleCancelButton={handleCloseConfirmModal}
-          heading="지금..나가시게요..?"
-          paragraph="저장 안된 내용은..날아갈 수 있다능.."
-          setIsOpenModal={setIsOpenConfirmModal}
-        />
-      )}
-    </>
+    <ApplyLayout
+      heading={PLATFORM_HEADINGS[router.asPath as keyof PlatformHeadings]}
+      role={PLATFORM_ROLE[router.asPath as keyof PlatformHeadings]}
+      application={application}
+      isSubmited={isSubmited}
+    />
   );
 };
 

--- a/pages/apply/[platformName].tsx
+++ b/pages/apply/[platformName].tsx
@@ -15,9 +15,10 @@ import { useState } from 'react';
 
 interface ApplyProps {
   application: Application;
+  isSubmited: boolean;
 }
 
-const Apply = ({ application }: ApplyProps) => {
+const Apply = ({ application, isSubmited }: ApplyProps) => {
   const router = useRouter();
   const [isOpenConfirmModal, setIsOpenConfirmModal] = useState(false);
   const [isOpenSuccessSubmitedModal, setIsOpenSuccessSubmitedModal] = useState(false);
@@ -39,6 +40,7 @@ const Apply = ({ application }: ApplyProps) => {
         application={application}
         isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
         setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+        isSubmited={isSubmited}
       />
       {isOpenConfirmModal && (
         <ConfirmModalDialog
@@ -84,6 +86,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     })
   ).data;
 
+  const isSubmited = applications.some(({ status }) => status === 'SUBMITTED');
+
   const currentApplication = applications.find(
     ({ team }) => team.teamId === teamIds[currentApplyPlatform],
   );
@@ -96,6 +100,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       props: {
         application: application?.data,
+        isSubmited,
       },
     };
   }
@@ -107,6 +112,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       application: application?.data,
+      isSubmited,
     },
   };
 };

--- a/pages/my-page/application-detail/[applicationId].tsx
+++ b/pages/my-page/application-detail/[applicationId].tsx
@@ -1,10 +1,8 @@
 import { applicationApiService } from '@/api/services';
-import { ConfirmModalDialog, ApplicationDetailLayout } from '@/components';
-import { usePreventPageChange } from '@/hooks';
+import { ApplicationDetailLayout } from '@/components';
 import { Application } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
-import { useState } from 'react';
 
 interface ApplicationDetailProps {
   application: Application;
@@ -12,39 +10,7 @@ interface ApplicationDetailProps {
 }
 
 const ApplicationDetail = ({ application, isSubmited }: ApplicationDetailProps) => {
-  const [isOpenConfirmModal, setIsOpenConfirmModal] = useState(false);
-  const [isOpenSuccessSubmitedModal, setIsOpenSuccessSubmitedModal] = useState(false);
-
-  const { handleMoveAfterBlocking } = usePreventPageChange(setIsOpenConfirmModal, [
-    isOpenConfirmModal,
-    isOpenSuccessSubmitedModal,
-  ]);
-
-  const handleCloseConfirmModal = () => {
-    setIsOpenConfirmModal(false);
-  };
-
-  return (
-    <>
-      <ApplicationDetailLayout
-        application={application}
-        isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-        setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
-        isSubmited={isSubmited}
-      />
-      {isOpenConfirmModal && (
-        <ConfirmModalDialog
-          approvalButtonMessage="나가기"
-          cancelButtonMessage="머물기"
-          handleApprovalButton={handleMoveAfterBlocking}
-          handleCancelButton={handleCloseConfirmModal}
-          heading="지금..나가시게요..?"
-          paragraph="저장 안된 내용은..날아갈 수 있다능.."
-          setIsOpenModal={setIsOpenConfirmModal}
-        />
-      )}
-    </>
-  );
+  return <ApplicationDetailLayout application={application} isSubmited={isSubmited} />;
 };
 
 export const getServerSideProps: GetServerSideProps<ApplicationDetailProps> = async (context) => {

--- a/pages/my-page/application-detail/[applicationId].tsx
+++ b/pages/my-page/application-detail/[applicationId].tsx
@@ -8,9 +8,10 @@ import { useState } from 'react';
 
 interface ApplicationDetailProps {
   application: Application;
+  isSubmited: boolean;
 }
 
-const ApplicationDetail = ({ application }: ApplicationDetailProps) => {
+const ApplicationDetail = ({ application, isSubmited }: ApplicationDetailProps) => {
   const [isOpenConfirmModal, setIsOpenConfirmModal] = useState(false);
   const [isOpenSuccessSubmitedModal, setIsOpenSuccessSubmitedModal] = useState(false);
 
@@ -29,6 +30,7 @@ const ApplicationDetail = ({ application }: ApplicationDetailProps) => {
         application={application}
         isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
         setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+        isSubmited={isSubmited}
       />
       {isOpenConfirmModal && (
         <ConfirmModalDialog
@@ -45,7 +47,7 @@ const ApplicationDetail = ({ application }: ApplicationDetailProps) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<ApplicationDetailProps> = async (context) => {
   const session = await getSession(context);
 
   if (!session) {
@@ -57,13 +59,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const applicationRes = await applicationApiService.getApplicationDetail({
-    accessToken: session.accessToken,
-    applicationId: parseInt(context.params?.applicationId as string, 10),
+  const applicationsRes = await applicationApiService.getApplications({
+    accessToken: session?.accessToken,
   });
 
   // TODO:(하준) API 실패 응답시 띄워 줄 UI나 동작이 정의되면 변경
-  if (applicationRes.code !== 'SUCCESS')
+  if (applicationsRes.code !== 'SUCCESS')
     return {
       redirect: {
         permanent: false,
@@ -71,9 +72,27 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       },
     };
 
+  const applications = applicationsRes.data;
+
+  const isSubmited = applications.some(({ status }) => status === 'SUBMITTED');
+
+  const application = applications.find(
+    ({ applicationId }) => applicationId === parseInt(context.params?.applicationId as string, 10),
+  );
+
+  if (!application) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+  }
+
   return {
     props: {
-      application: applicationRes?.data,
+      application,
+      isSubmited,
     },
   };
 };

--- a/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
+++ b/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
@@ -25,12 +25,14 @@ interface ApplicationDetailLayoutProps {
   application: Application;
   isOpenSuccessSubmitedModal: boolean;
   setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
+  isSubmited: boolean;
 }
 
 const ApplicationDetailLayout = ({
   application,
   isOpenSuccessSubmitedModal,
   setIsOpenSuccessSubmitedModal,
+  isSubmited,
 }: ApplicationDetailLayoutProps) => {
   return (
     <section>
@@ -48,6 +50,7 @@ const ApplicationDetailLayout = ({
           application={application}
           isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
           setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+          isSubmited={isSubmited}
         />
       </Styled.Layout>
     </section>

--- a/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
+++ b/src/components/applicationDetail/ApplicationDetailLayout/ApplicationDetailLayout.component.tsx
@@ -1,6 +1,5 @@
 import { ApplyForm } from '@/components';
 import { Application, TeamName } from '@/types/dto';
-import { Dispatch, SetStateAction } from 'react';
 import * as Styled from './ApplicationDetailLayout.styled';
 
 export const PLATFORM_HEADINGS: Record<TeamName, string> = {
@@ -23,17 +22,10 @@ export const PLATFORM_ROLE: Record<TeamName, string> = {
 
 interface ApplicationDetailLayoutProps {
   application: Application;
-  isOpenSuccessSubmitedModal: boolean;
-  setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
   isSubmited: boolean;
 }
 
-const ApplicationDetailLayout = ({
-  application,
-  isOpenSuccessSubmitedModal,
-  setIsOpenSuccessSubmitedModal,
-  isSubmited,
-}: ApplicationDetailLayoutProps) => {
+const ApplicationDetailLayout = ({ application, isSubmited }: ApplicationDetailLayoutProps) => {
   return (
     <section>
       <Styled.ApplicationDetailHeadingWrapper>
@@ -46,12 +38,7 @@ const ApplicationDetailLayout = ({
         </Styled.ApplicationDetailHeadingInner>
       </Styled.ApplicationDetailHeadingWrapper>
       <Styled.Layout>
-        <ApplyForm
-          application={application}
-          isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-          setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
-          isSubmited={isSubmited}
-        />
+        <ApplyForm application={application} isSubmited={isSubmited} />
       </Styled.Layout>
     </section>
   );

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -227,7 +227,7 @@ const ApplyForm = ({
           <Styled.PersonalInformationWrapper>
             <LabeledInput
               id={APPLY_FORM_KEYS.email}
-              value={session.data?.user?.email || ''}
+              value={applicant.email}
               disabled
               label="이메일"
               $size="md"

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -195,6 +195,9 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
     } else setIsOpenFailedSubmitedModal(true);
   };
 
+  const isDetailPageAndSubmited =
+    isSubmited && router.pathname === PATH_NAME.MY_PAGE_APPLICATON_DETAIL;
+
   return (
     <>
       <form onSubmit={handleSubmit(handleOpenSubmitModal)}>
@@ -214,6 +217,7 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
               placeholder="내용을 입력해주세요"
               label="이름"
               required
+              disabled={isDetailPageAndSubmited}
               $size="md"
               onBlur={() => {
                 handleValidateForm(APPLY_FORM_KEYS.userName);
@@ -238,6 +242,7 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
               placeholder="010-1234-5678"
               label="전화번호"
               required
+              disabled={isDetailPageAndSubmited}
               isError={!!errors.phone}
               errorMessage={errors.phone?.message}
               $size="md"
@@ -285,6 +290,7 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
                     label={question.content}
                     placeholder="내용을 입력해주세요."
                     required={question.required}
+                    disabled={isDetailPageAndSubmited}
                     id={uniqueQuestionId}
                     isError={!!errors[uniqueQuestionId]}
                     errorMessage={errors[uniqueQuestionId]?.message}
@@ -312,6 +318,7 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
                     id={uniqueQuestionId}
                     label={question.content}
                     required={question.required}
+                    disabled={isDetailPageAndSubmited}
                     $size="md"
                     placeholder="내용을 입력해주세요."
                     isError={!!errors[uniqueQuestionId]}
@@ -330,8 +337,9 @@ const ApplyForm = ({ application, isSubmited }: ApplyFormProps) => {
         </Styled.QuestionListSection>
         <LabeledCheckbox
           {...register(APPLY_FORM_KEYS.isAgreePersonalInfo)}
-          checked={watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+          checked={isDetailPageAndSubmited ? true : watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
           id={APPLY_FORM_KEYS.isAgreePersonalInfo}
+          disabled={isDetailPageAndSubmited}
         >
           {/* TODO:(하준) 개인정보 수집 및 이용 동의 페이지 링크로 수정 */}
           <a href="http://devfolio.world" target="_blank" rel="noreferrer">

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -335,14 +335,17 @@ const ApplyForm = ({
         </LabeledCheckbox>
         <Styled.ControlSection>
           {isSubmited ? (
-            router.pathname === PATH_NAME.APPLY_PAGE || application.status === 'SUBMITTED' ? (
-              <Styled.AlreadySubmitedButton type="button" disabled>
-                이미 제출한 지원서가 있습니다.
-              </Styled.AlreadySubmitedButton>
-            ) : (
+            router.pathname === PATH_NAME.MY_PAGE_APPLICATON_DETAIL &&
+            application.status === 'SUBMITTED' ? (
               <Styled.SubmitedCompletedButton type="button" disabled>
                 제출 완료된 지원서 입니다.
               </Styled.SubmitedCompletedButton>
+            ) : (
+              isSubmited && (
+                <Styled.AlreadySubmitedButton type="button" disabled>
+                  이미 제출한 지원서가 있습니다.
+                </Styled.AlreadySubmitedButton>
+              )
             )
           ) : (
             <>

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -6,7 +6,7 @@ import {
   LabeledInput,
   LabeledTextArea,
 } from '@/components';
-import { HOME_PAGE, MY_PAGE_APPLICATON_DETAIL } from '@/constants';
+import { HOME_PAGE, MY_PAGE_APPLICATON_DETAIL, PATH_NAME } from '@/constants';
 import { ValueOf } from '@/types';
 import { Application } from '@/types/dto';
 import { useSession } from 'next-auth/react';
@@ -27,6 +27,7 @@ interface ApplyFormProps {
   application: Application;
   isOpenSuccessSubmitedModal: boolean;
   setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
+  isSubmited: boolean;
 }
 
 interface ApplyFormValues extends FieldValues {
@@ -47,6 +48,7 @@ const ApplyForm = ({
   application,
   isOpenSuccessSubmitedModal,
   setIsOpenSuccessSubmitedModal,
+  isSubmited,
 }: ApplyFormProps) => {
   const session = useSession();
   const router = useRouter();
@@ -70,6 +72,10 @@ const ApplyForm = ({
   const questionsAndAnswers = questions.map((question, index) => {
     const questionMatchAnswer =
       answers.find(({ questionId }) => question.questionId === questionId) || answers[index];
+
+    if (isSubmited && router.pathname === PATH_NAME.APPLY_PAGE) {
+      return { question, answer: { ...questionMatchAnswer, content: '' } };
+    }
 
     return { question, answer: questionMatchAnswer };
   });
@@ -317,20 +323,34 @@ const ApplyForm = ({
           에 동의합니다.
         </LabeledCheckbox>
         <Styled.ControlSection>
-          <Styled.TempSaveButton
-            type="button"
-            disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
-            onClick={handleTempSaveApplication}
-            ref={tempSaveButtonRef}
-          >
-            임시저장하기
-          </Styled.TempSaveButton>
-          <Styled.SubmitButton
-            disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
-            ref={submitButtonRef}
-          >
-            제출하기
-          </Styled.SubmitButton>
+          {isSubmited ? (
+            router.pathname === PATH_NAME.APPLY_PAGE || application.status === 'SUBMITTED' ? (
+              <Styled.AlreadySubmitedButton type="button" disabled>
+                이미 제출한 지원서가 있습니다.
+              </Styled.AlreadySubmitedButton>
+            ) : (
+              <Styled.SubmitedCompletedButton type="button" disabled>
+                제출 완료된 지원서 입니다.
+              </Styled.SubmitedCompletedButton>
+            )
+          ) : (
+            <>
+              <Styled.TempSaveButton
+                type="button"
+                disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+                onClick={handleTempSaveApplication}
+                ref={tempSaveButtonRef}
+              >
+                임시저장하기
+              </Styled.TempSaveButton>
+              <Styled.SubmitButton
+                disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+                ref={submitButtonRef}
+              >
+                제출하기
+              </Styled.SubmitButton>
+            </>
+          )}
           <Styled.BackToListLink href={HOME_PAGE}>목록으로 돌아가기</Styled.BackToListLink>
         </Styled.ControlSection>
       </form>

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -86,6 +86,7 @@ const ApplyForm = ({
     watch,
     setValue,
     trigger,
+    setFocus,
     formState: { errors },
   } = useForm<ApplyFormValues>();
 
@@ -116,6 +117,16 @@ const ApplyForm = ({
     if (session.status === 'unauthenticated') return;
 
     const { userName, phone, isAgreePersonalInfo } = watch();
+
+    if (!(await trigger('userName'))) {
+      setFocus('userName');
+      return;
+    }
+
+    if (!(await trigger('phone'))) {
+      setFocus('phone');
+      return;
+    }
 
     const updateApplicationRequest = {
       applicantName: userName,

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -75,6 +75,24 @@ export const SubmitButton = styled.button`
   `}
 `;
 
+export const AlreadySubmitedButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.primary}
+    display: inline-block;
+    width: 100%;
+    text-align: center;
+  `}
+`;
+
+export const SubmitedCompletedButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.defaultLine}
+    display: inline-block;
+    width: 100%;
+    text-align: center;
+  `}
+`;
+
 export const BackToListLink = styled(LinkTo)`
   ${({ theme }) => css`
     ${theme.button.type.defaultLine}
@@ -84,7 +102,6 @@ export const BackToListLink = styled(LinkTo)`
     text-align: center;
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
-      width: 100%;
       margin-top: 6rem;
     }
   `}

--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -49,6 +49,9 @@ const ApplyLayout = ({
   isSubmited,
 }: ApplyLayoutProps) => {
   const [isOpenAlreadySubmitedModal, setIsOpenAlreadySubmitedModal] = useState(isSubmited);
+  const [isOpenTempSavedModal, setIsOpenTempSavedModal] = useState(
+    application.status === 'WRITING',
+  );
   return (
     <>
       <Styled.Layout>
@@ -70,6 +73,14 @@ const ApplyLayout = ({
           paragraph="이미 한 번 지원서를 제출하셨다면 이제 또 다른 지원서는 제출하지 못합니다."
           setIsOpenModal={setIsOpenAlreadySubmitedModal}
           handleApprovalButton={() => setIsOpenAlreadySubmitedModal(false)}
+        />
+      )}
+      {isOpenTempSavedModal && !isSubmited && (
+        <AlertModalDialog
+          heading="이미 작성 중이던 지원서가 있습니다."
+          paragraph="작성 중이던 지원서 내용을 불러왔습니다."
+          setIsOpenModal={setIsOpenTempSavedModal}
+          handleApprovalButton={() => setIsOpenTempSavedModal(false)}
         />
       )}
     </>

--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -1,4 +1,4 @@
-import { ApplyForm } from '@/components';
+import { AlertModalDialog, ApplyForm } from '@/components';
 import {
   APPLY_ANDROID_PAGE,
   APPLY_DESIGN_PAGE,
@@ -8,7 +8,7 @@ import {
   APPLY_SPRING_PAGE,
 } from '@/constants';
 import { Application } from '@/types/dto';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import * as Styled from './ApplyLayout.styled';
 
 export const PLATFORM_HEADINGS = {
@@ -37,6 +37,7 @@ interface ApplyLayoutProps {
   application: Application;
   isOpenSuccessSubmitedModal: boolean;
   setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
+  isSubmited: boolean;
 }
 
 const ApplyLayout = ({
@@ -45,20 +46,33 @@ const ApplyLayout = ({
   application,
   isOpenSuccessSubmitedModal,
   setIsOpenSuccessSubmitedModal,
+  isSubmited,
 }: ApplyLayoutProps) => {
+  const [isOpenAlreadySubmitedModal, setIsOpenAlreadySubmitedModal] = useState(isSubmited);
   return (
-    <Styled.Layout>
-      <Styled.ApplyHeading>지원서 작성</Styled.ApplyHeading>
-      <section>
-        <Styled.PlatformHeading>{heading}</Styled.PlatformHeading>
-        <Styled.PlatformRole>{role}</Styled.PlatformRole>
-        <ApplyForm
-          application={application}
-          isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-          setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+    <>
+      <Styled.Layout>
+        <Styled.ApplyHeading>지원서 작성</Styled.ApplyHeading>
+        <section>
+          <Styled.PlatformHeading>{heading}</Styled.PlatformHeading>
+          <Styled.PlatformRole>{role}</Styled.PlatformRole>
+          <ApplyForm
+            application={application}
+            isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
+            setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
+            isSubmited={isSubmited}
+          />
+        </section>
+      </Styled.Layout>
+      {isOpenAlreadySubmitedModal && (
+        <AlertModalDialog
+          heading="1인 1팀 1지원만 가능합니다!"
+          paragraph="이미 한 번 지원서를 제출하셨다면 이제 또 다른 지원서는 제출하지 못합니다."
+          setIsOpenModal={setIsOpenAlreadySubmitedModal}
+          handleApprovalButton={() => setIsOpenAlreadySubmitedModal(false)}
         />
-      </section>
-    </Styled.Layout>
+      )}
+    </>
   );
 };
 

--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -8,7 +8,7 @@ import {
   APPLY_SPRING_PAGE,
 } from '@/constants';
 import { Application } from '@/types/dto';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import * as Styled from './ApplyLayout.styled';
 
 export const PLATFORM_HEADINGS = {
@@ -35,19 +35,10 @@ interface ApplyLayoutProps {
   heading: string;
   role: string;
   application: Application;
-  isOpenSuccessSubmitedModal: boolean;
-  setIsOpenSuccessSubmitedModal: Dispatch<SetStateAction<boolean>>;
   isSubmited: boolean;
 }
 
-const ApplyLayout = ({
-  heading,
-  role,
-  application,
-  isOpenSuccessSubmitedModal,
-  setIsOpenSuccessSubmitedModal,
-  isSubmited,
-}: ApplyLayoutProps) => {
+const ApplyLayout = ({ heading, role, application, isSubmited }: ApplyLayoutProps) => {
   const [isOpenAlreadySubmitedModal, setIsOpenAlreadySubmitedModal] = useState(isSubmited);
   const [isOpenTempSavedModal, setIsOpenTempSavedModal] = useState(
     application.status === 'WRITING',
@@ -59,12 +50,7 @@ const ApplyLayout = ({
         <section>
           <Styled.PlatformHeading>{heading}</Styled.PlatformHeading>
           <Styled.PlatformRole>{role}</Styled.PlatformRole>
-          <ApplyForm
-            application={application}
-            isOpenSuccessSubmitedModal={isOpenSuccessSubmitedModal}
-            setIsOpenSuccessSubmitedModal={setIsOpenSuccessSubmitedModal}
-            isSubmited={isSubmited}
-          />
+          <ApplyForm application={application} isSubmited={isSubmited} />
         </section>
       </Styled.Layout>
       {isOpenAlreadySubmitedModal && (

--- a/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@/components';
-import { Dispatch, MouseEventHandler, MutableRefObject, SetStateAction } from 'react';
+import { Dispatch, MouseEventHandler, MutableRefObject, SetStateAction, useEffect } from 'react';
 import * as Styled from './AlertModalDialog.styled';
 
 export interface AlertModalDialogProps {
@@ -10,6 +10,7 @@ export interface AlertModalDialogProps {
   beforeRef?: MutableRefObject<HTMLButtonElement>;
   deemClose?: boolean;
   escClose?: boolean;
+  enterClose?: boolean;
 }
 
 const AlertModalDialog = ({
@@ -20,7 +21,21 @@ const AlertModalDialog = ({
   setIsOpenModal,
   deemClose,
   escClose,
+  enterClose = true,
 }: AlertModalDialogProps) => {
+  const handleCloseModalWithEnterHandler = ({ key }: KeyboardEvent) => {
+    if (key === 'Enter') {
+      setIsOpenModal(false);
+    }
+  };
+
+  useEffect(() => {
+    if (enterClose) window.addEventListener('keyup', handleCloseModalWithEnterHandler);
+
+    return () => {
+      if (enterClose) window.removeEventListener('keyup', handleCloseModalWithEnterHandler);
+    };
+  });
   return (
     <Modal
       beforeRef={beforeRef}

--- a/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
@@ -7,7 +7,7 @@ export interface AlertModalDialogProps {
   paragraph: string;
   handleApprovalButton: MouseEventHandler<HTMLButtonElement>;
   setIsOpenModal: Dispatch<SetStateAction<boolean>>;
-  beforeRef: MutableRefObject<HTMLButtonElement>;
+  beforeRef?: MutableRefObject<HTMLButtonElement>;
   deemClose?: boolean;
   escClose?: boolean;
 }

--- a/src/components/common/LabeledCheckbox/LabeledCheckbox.component.tsx
+++ b/src/components/common/LabeledCheckbox/LabeledCheckbox.component.tsx
@@ -8,14 +8,21 @@ interface LabeledCheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 const LabeledCheckbox = forwardRef<HTMLInputElement, LabeledCheckboxProps>(
-  ({ id, children, checked, ...restProps }, ref) => {
+  ({ id, children, checked, disabled = false, ...restProps }, ref) => {
     return (
       <Styled.LabeledCheckboxWrapper>
         <Styled.AgreePersonalInfoLabel htmlFor={id}>{children}</Styled.AgreePersonalInfoLabel>
         <Styled.CheckboxWrapper>
-          <Styled.CustomCheckbox isChecked={checked} />
+          <Styled.CustomCheckbox isChecked={checked} disabled={disabled} />
           <Styled.CustomCheckIcon />
-          <Styled.A11yCheckbox type="checkbox" id={id} name={id} ref={ref} {...restProps} />
+          <Styled.A11yCheckbox
+            type="checkbox"
+            id={id}
+            name={id}
+            ref={ref}
+            disabled={disabled}
+            {...restProps}
+          />
         </Styled.CheckboxWrapper>
       </Styled.LabeledCheckboxWrapper>
     );

--- a/src/components/common/LabeledCheckbox/LabeledCheckbox.styled.ts
+++ b/src/components/common/LabeledCheckbox/LabeledCheckbox.styled.ts
@@ -29,15 +29,20 @@ export const A11yCheckbox = styled.input`
 
 interface CustomCheckoutProps {
   isChecked: boolean;
+  disabled: boolean;
 }
 
 export const CustomCheckbox = styled.label<CustomCheckoutProps>`
-  ${({ theme, isChecked }) => css`
+  ${({ theme, isChecked, disabled }) => css`
     display: inline-block;
     width: 100%;
     height: 100%;
     padding: 0;
-    background: ${isChecked ? theme.colors.purple70 : theme.colors.white};
+    background: ${disabled && isChecked
+      ? theme.colors.gray30
+      : isChecked
+      ? theme.colors.purple70
+      : theme.colors.white};
     border: ${isChecked ? 0 : '0.1rem'} solid ${theme.colors.gray30};
     border-radius: 0.2rem;
   `}

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -20,3 +20,11 @@ export const FAQ_ANDROID_PAGE = `/faq/${teamUrls.android}`;
 export const MY_PAGE_ACCOUNT = '/my-page/account';
 export const MY_PAGE_APPLY_STATUS = '/my-page/apply-status';
 export const MY_PAGE_APPLICATON_DETAIL = '/my-page/application-detail'; // 사용시 `/${id}` 넣어줄것 (동적 라우트)
+
+export const PATH_NAME = {
+  APPLY_PAGE: '/apply/[platformName]',
+  FAQ_PAGE: '/faq/[platformName]',
+  MY_PAGE_ACCOUNT: '/my-page/account',
+  MY_PAGE_APPLY_STATUS: '/my-page/apply-status',
+  MY_PAGE_APPLICATON_DETAIL: '/my-page/application-detail/[applicationId]',
+};


### PR DESCRIPTION
## 변경사항

- 지원서 폼에서 불러오는 email을 session이용하여 받아오는 데이터에서 꺼내려고 하다보니 CSR처럼 깜빡임 현상이 일어나게되어 이미 존재하는 application객체 내부의 applicant 객체에서 꺼내주었습니다.

- 조건부 렌더링을 할때 여러가지 조건을 판별해줘야할때가 있어서 삼항 연산자를 3depth이상 쓸 수 있게끔 eslint 설정을 변경해주었습니다.
- Next Router를 사용해 동적 라우팅이 적용된 페이지에서 pathname을 참조하면 실제 url이 아닌 동적 라우팅 페이지명으로 나오게 되는게 이 값을 비교하기 위한 상수를 정의해주었습니다.
- AlertModalDialog를 특정 조건에서 자동으로 띄워주는 상황이 생겨 beforeRef Prop을 Optional로 변경해주었습니다. 그리고 Enter키로도 닫을 수 있게 keyUp 이벤트도 하나 추가해주었습니다.
- 이미 제출한 지원서가 있는 유저는 중복 제출을 하지 못하게끔 지원하기 페이지에 접근했을때 Alert을 띄워주고 제출하기와 임시저장 버튼을 숨김으로써 중복 제출을 막아주었습니다.
- 아직 제출한 지원서가 없고 임시저장 한 플랫폼의 지원서에 들어왔을시에 임시저장 한 지원서가 있다는 Alert을 띄워주게끔 해주었습니다.
- 임시저장시에 이름도 입력 안 한 상태에서 정상적으로 처리해주게 되면 지원 현황 목록에 이름이 비어서 나오게 되기 때문에 이름은 임시저장시에도 필수값인것으로 변경해주었습니다.
- 전화번호는 유효성 검사하는 경우가 입력하지 않았을때, 전화번호 형식이 올바르지 않을때 2가지이기 때문에 아무값을 입력했을때도 임시저장이 정상적으로 동작하는게 어색해보여 임시저장시 전화번호도 유효성 검사를 하게끔 변경해주었습니다.
- 지원하기 페이지에서 폼 요소에 아무런 변화가 없다면 페이지 이동 블락킹을 해주지 않도록 변경해주었습니다.
- 제출한 지원서가 하나라도 있을시 지원서 상세페이지에서 모든 폼 요소를 disabled처리하게끔 해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
