### PR TITLE
배포를 위해 Node.js 버전을 14,16만 허용한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.5.5"
   },
   "engines": {
-    "node": "^16.13.0",
+    "node": "^14.19.0 || ^16.13.0",
     "npm": "please-use-yarn",
     "yarn": "^1.22.17"
   },


### PR DESCRIPTION
## 변경사항

- 배포를 위해 Node.js 버전을 14,16을 허용하게끔 변경하였습니다.

### 작업 유형

- 배포 관련
- 프로젝트 설정(웹팩, 바벨, 린팅 등)

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
