### PR TITLE
MainNavigation 마이페이지 버튼 옆 화살표 아이콘 색상값 변경

### DIFF
--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -137,6 +137,10 @@ export const MyPageButton = styled.button<MyPageButtonProps>`
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       ${theme.fonts.kr.medium15};
+
+      & > span {
+        margin-right: 0.4rem;
+      }
     }
   `}
 `;

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -123,6 +123,10 @@ export const MyPageButton = styled.button<MyPageButtonProps>`
           `};
     }
 
+    & > svg > path {
+      stroke: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
+    }
+
     &:hover {
       color: ${theme.colors.purple70};
 


### PR DESCRIPTION
## 변경사항

- MainNavigation 내부의 마이페이지 버튼 옆 화살표 버튼이 홈페이지에서 white color가 적용되지 않는 이슈가 있어서 스타일 코드를 추가해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
