### PR TITLE
Fix: iOS 사파리 브라우저 모달 스크롤 방지 및 하단 url바로 인한 UI버그 방어

### DIFF
--- a/src/components/common/Modal/Modal.component.tsx
+++ b/src/components/common/Modal/Modal.component.tsx
@@ -42,6 +42,9 @@ const Modal = ({
   useEffect(() => {
     const $rootNode = document.getElementById('__next');
     $rootNode?.setAttribute('aria-hidden', 'true');
+
+    const handleLockScroll = (e: TouchEvent) => e.preventDefault();
+    window.addEventListener('touchmove', handleLockScroll, { passive: false });
     document.body.style.overflow = 'hidden';
 
     const handleCloseModalWithEscHandler = ({ key }: KeyboardEvent) => {
@@ -84,6 +87,8 @@ const Modal = ({
 
     return () => {
       $rootNode?.removeAttribute('aria-hidden');
+      window.removeEventListener('touchmove', handleLockScroll);
+
       document.body.style.overflow = 'unset';
 
       if (escClose) window.removeEventListener('keyup', handleCloseModalWithEscHandler);
@@ -95,13 +100,15 @@ const Modal = ({
 
   return (
     <Portal elementId="modal-root" mounted={mounted}>
-      <Styled.Modal
-        ref={dialogRef}
-        tabIndex={-1}
-        onClick={deemClose ? handleCloseModalWithMouseHandler : undefined}
-      >
-        {children}
-      </Styled.Modal>
+      <Styled.OverSizeModal>
+        <Styled.Modal
+          ref={dialogRef}
+          tabIndex={-1}
+          onClick={deemClose ? handleCloseModalWithMouseHandler : undefined}
+        >
+          {children}
+        </Styled.Modal>
+      </Styled.OverSizeModal>
     </Portal>
   );
 };

--- a/src/components/common/Modal/Modal.styled.ts
+++ b/src/components/common/Modal/Modal.styled.ts
@@ -1,6 +1,20 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+export const OverSizeModal = styled.div`
+  ${({ theme }) => css`
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: ${theme.zIndex.header};
+    width: 100vw;
+    height: 200vh;
+    background: rgba(0, 0, 0, 0.5);
+  `}
+`;
+
 export const Modal = styled.div`
   ${({ theme }) => css`
     position: fixed;
@@ -15,6 +29,5 @@ export const Modal = styled.div`
     width: 100%;
     height: 100%;
     padding: 0 2rem;
-    background: rgba(0, 0, 0, 0.5);
   `}
 `;


### PR DESCRIPTION
## 변경사항

- 모달이 띄워졌을때 iOS 사파리 브라우저에서만 body의 `overflow: hidden` 값이 적용되는것으로 스크롤이 막히지 않는 이슈가 생겨 window의 touchmove 이벤트의 기본동작을 막아주어 처리했습니다.

- iOS에서는 스크롤에 따라 url바가 사라졌다가 다시 나타나며 디바이스의 세로 뷰포트 값이 동적으로 변하는데 이것때문에 아래 사진과 같이 모달에 비는 영역이 나타나게 됩니다. 실제 딤 요소를 따로 분리해주어 이 요소의 height를 200vh로 오버하게 주어 해당 현상을 막아주었습니다.

![KakaoTalk_Photo_2022-02-24-07-23-36](https://user-images.githubusercontent.com/71176945/155419700-8afc0f18-1410-4a80-b31e-0e49e6e0044f.jpeg)


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
