### PR TITLE
지원하기 클릭 시 로그인 성공 후 지원 페이지로 이동

### DIFF
--- a/src/components/common/SignInModalDialog/SignInModalDialog.component.tsx
+++ b/src/components/common/SignInModalDialog/SignInModalDialog.component.tsx
@@ -27,9 +27,15 @@ export interface SignInModalDialogProps {
   type: 'login' | 'apply';
   setIsOpenModal: Dispatch<SetStateAction<boolean>>;
   beforeRef: MutableRefObject<HTMLButtonElement>;
+  callbackUrl?: string;
 }
 
-const SignInModalDialog = ({ type, setIsOpenModal, beforeRef }: SignInModalDialogProps) => {
+const SignInModalDialog = ({
+  type,
+  setIsOpenModal,
+  beforeRef,
+  callbackUrl,
+}: SignInModalDialogProps) => {
   const { size } = useDetectViewPort();
 
   const handleCloseSignInModal: MouseEventHandler<HTMLButtonElement> = () => {
@@ -37,7 +43,7 @@ const SignInModalDialog = ({ type, setIsOpenModal, beforeRef }: SignInModalDialo
   };
 
   const handleSignIn: MouseEventHandler<HTMLButtonElement> = () => {
-    signIn('google');
+    signIn('google', { callbackUrl });
   };
 
   return (

--- a/src/components/recruit/ApplyLinkButton/ApplyLinkButton.component.tsx
+++ b/src/components/recruit/ApplyLinkButton/ApplyLinkButton.component.tsx
@@ -34,6 +34,7 @@ const ApplyLinkButton = ({ applyPath }: ApplyLinkProps) => {
           type="apply"
           setIsOpenModal={setIsOpenSignInModal}
           beforeRef={buttonRef}
+          callbackUrl={applyPath}
         />
       )}
     </>


### PR DESCRIPTION
## 변경사항

- 지원하기 클릭 시 로그인 되어있지 않은 경우 로그인 모달을 띄우고 성공 시 /apply/[platformName] 경로로 이동시킵니다.
- 기존 SignInModalDialog에 optional한 prop으로 전달하게끔하여 callbackUrl이 존재한다면 해당 경로로 라우팅시키게끔 수정하였습니다!

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
