### PR TITLE
이메일 변경 기능 삭제로 인한 지원서 페이지 워딩 삭제

### DIFF
--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -281,9 +281,6 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
               required
               type="email"
             />
-            <Styled.ModifyEmailMessage>
-              이메일 수정은 마이페이지에서 가능합니다.
-            </Styled.ModifyEmailMessage>
           </Styled.PersonalInformationWrapper>
         </Styled.PersonalInformationSection>
         <Styled.QuestionListSection>

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -21,14 +21,10 @@ export const PersonalInformationWrapper = styled.div`
   width: 100%;
   max-width: 53.2rem;
   margin-bottom: 3.6rem;
-`;
 
-export const ModifyEmailMessage = styled.p`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.regular15};
-    margin-top: 0.6rem;
-    color: ${theme.colors.gray60};
-  `}
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 `;
 
 export const QuestionListSection = styled.section`


### PR DESCRIPTION
## 변경사항

- 이메일 변경 기능 삭제로 인하여 지원서 작성 페이지에서 `이메일 변경은 마이페이지에서 가능합니다` 워딩을 삭제해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
