### PR TITLE
footer 반응형 브레이크 포인트 변경 및 내부 여백 변경

### DIFF
--- a/src/components/common/Footer/Footer.styled.ts
+++ b/src/components/common/Footer/Footer.styled.ts
@@ -14,10 +14,10 @@ export const Footer = styled.footer<FooterProps>`
     padding: 4rem 0;
     background: ${currentPage === HOME_PAGE ? theme.colors.gray95 : theme.colors.white};
 
-    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+    @media (max-width: ${theme.breakPoint.media.tabletL}) {
       flex-flow: column nowrap;
-      height: 11rem;
-      padding: 2rem 0;
+      height: 17rem;
+      padding: 2rem 0 8rem;
     }
   `}
 `;
@@ -33,7 +33,7 @@ export const FooterInner = styled.div`
     margin: 0 auto;
     padding: 0 2rem;
 
-    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+    @media (max-width: ${theme.breakPoint.media.tabletL}) {
       flex-flow: column nowrap;
     }
   `}


### PR DESCRIPTION
## 변경사항

- footer의 반응형 브레이크 포인트를 tabletS -> tabletL로 변경했습니다.
- tabletL이하의 디자인에서 padding-bottom을 2rem -> 8rem으로 변경했습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
