### PR TITLE
Skeleton 컴포넌트 추가 및 GNB에 적용

### DIFF
--- a/src/components/common/MainNavigation/MainNavigation.component.tsx
+++ b/src/components/common/MainNavigation/MainNavigation.component.tsx
@@ -1,8 +1,7 @@
-import { FAQ_COMMON_PAGE, HOME_PAGE, RECRUIT_DETAILS_ID, VIEWPORT_SIZE } from '@/constants';
-import { LinkTo, SignInModalDialog, MyPageTab } from '@/components';
-import DivisionLine from '@/assets/svg/division-line.svg';
-import { MouseEventHandler, MutableRefObject, useEffect, useRef, useState } from 'react';
-import { useDetectOutsideClick, useDetectViewPort } from '@/hooks';
+import { FAQ_COMMON_PAGE, HOME_PAGE, RECRUIT_DETAILS_ID } from '@/constants';
+import { LinkTo, SignInModalDialog, MyPageTab, Skeleton } from '@/components';
+import { MouseEventHandler, MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { useDetectOutsideClick } from '@/hooks';
 import Router, { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import ChevronBottom12 from '@/assets/svg/chevron-bottom-12.svg';
@@ -10,8 +9,9 @@ import * as Styled from './MainNavigation.styled';
 
 const MainNavigation = () => {
   const session = useSession();
-  const { size } = useDetectViewPort();
   const { pathname: currentPage } = useRouter();
+
+  const isSessionLoading = useMemo(() => session.status === 'loading', [session.status]);
 
   const [isOpenSignInModal, setIsOpenSignInModal] = useState(false);
   const [isOpenMyPageTab, setIsOpenMyPageTab] = useState(false);
@@ -44,41 +44,51 @@ const MainNavigation = () => {
   return (
     <>
       <Styled.Nav>
-        <Styled.NavList currentPage={currentPage}>
+        <Styled.NavList currentPage={currentPage} isSessionLoading={isSessionLoading}>
           <li>
-            <LinkTo href={`${HOME_PAGE}#${RECRUIT_DETAILS_ID}`}>모집 공고</LinkTo>
+            <Skeleton color="rgba(255, 255, 255, 0.08)" width="10rem" isLoading={isSessionLoading}>
+              <LinkTo href={`${HOME_PAGE}#${RECRUIT_DETAILS_ID}`}>모집 공고</LinkTo>
+            </Skeleton>
           </li>
           <li>
-            <LinkTo href={FAQ_COMMON_PAGE}>자주 묻는 질문</LinkTo>
-            <DivisionLine width={size === VIEWPORT_SIZE.MOBILE ? '1' : '2'} />
+            <Skeleton
+              color="rgba(255, 255, 255, 0.08)"
+              width="10rem"
+              height="2.7rem"
+              isLoading={isSessionLoading}
+            >
+              <LinkTo href={FAQ_COMMON_PAGE}>자주 묻는 질문</LinkTo>
+            </Skeleton>
           </li>
           <li>
-            {session.status === 'authenticated' ? (
-              <div ref={MyPageTabWrapper}>
-                <Styled.MyPageButton
+            <Skeleton color="rgba(255, 255, 255, 0.08)" width="10rem" isLoading={isSessionLoading}>
+              {session.status === 'authenticated' ? (
+                <div ref={MyPageTabWrapper}>
+                  <Styled.MyPageButton
+                    type="button"
+                    currentPage={currentPage}
+                    onClick={handleToggleMyPageTab}
+                    isOpenMyPageTab={isOpenMyPageTab}
+                  >
+                    <span>내 페이지</span>
+                    <ChevronBottom12 />
+                  </Styled.MyPageButton>
+                  <MyPageTab
+                    isOpenMyPageTab={isOpenMyPageTab}
+                    setIsOpenMyPageTab={setIsOpenMyPageTab}
+                  />
+                </div>
+              ) : (
+                <Styled.SignInButton
                   type="button"
                   currentPage={currentPage}
-                  onClick={handleToggleMyPageTab}
-                  isOpenMyPageTab={isOpenMyPageTab}
+                  onClick={handleOpenSignInModal}
+                  ref={loginButtonRef}
                 >
-                  <span>내 페이지</span>
-                  <ChevronBottom12 />
-                </Styled.MyPageButton>
-                <MyPageTab
-                  isOpenMyPageTab={isOpenMyPageTab}
-                  setIsOpenMyPageTab={setIsOpenMyPageTab}
-                />
-              </div>
-            ) : (
-              <Styled.SignInButton
-                type="button"
-                currentPage={currentPage}
-                onClick={handleOpenSignInModal}
-                ref={loginButtonRef}
-              >
-                로그인
-              </Styled.SignInButton>
-            )}
+                  로그인
+                </Styled.SignInButton>
+              )}
+            </Skeleton>
           </li>
         </Styled.NavList>
       </Styled.Nav>

--- a/src/components/common/MainNavigation/MainNavigation.component.tsx
+++ b/src/components/common/MainNavigation/MainNavigation.component.tsx
@@ -1,17 +1,19 @@
 import { FAQ_COMMON_PAGE, HOME_PAGE, RECRUIT_DETAILS_ID } from '@/constants';
 import { LinkTo, SignInModalDialog, MyPageTab, Skeleton } from '@/components';
-import { MouseEventHandler, MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { MouseEventHandler, MutableRefObject, useEffect, useRef, useState } from 'react';
 import { useDetectOutsideClick } from '@/hooks';
 import Router, { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import ChevronBottom12 from '@/assets/svg/chevron-bottom-12.svg';
+import { colors } from '@/styles';
 import * as Styled from './MainNavigation.styled';
 
 const MainNavigation = () => {
   const session = useSession();
   const { pathname: currentPage } = useRouter();
 
-  const isSessionLoading = useMemo(() => session.status === 'loading', [session.status]);
+  const isSessionLoading = session.status === 'loading';
+  const skeletonColor = currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20;
 
   const [isOpenSignInModal, setIsOpenSignInModal] = useState(false);
   const [isOpenMyPageTab, setIsOpenMyPageTab] = useState(false);
@@ -46,13 +48,13 @@ const MainNavigation = () => {
       <Styled.Nav>
         <Styled.NavList currentPage={currentPage} isSessionLoading={isSessionLoading}>
           <li>
-            <Skeleton color="rgba(255, 255, 255, 0.08)" width="10rem" isLoading={isSessionLoading}>
+            <Skeleton color={skeletonColor} width="10rem" isLoading={isSessionLoading}>
               <LinkTo href={`${HOME_PAGE}#${RECRUIT_DETAILS_ID}`}>모집 공고</LinkTo>
             </Skeleton>
           </li>
           <li>
             <Skeleton
-              color="rgba(255, 255, 255, 0.08)"
+              color={skeletonColor}
               width="10rem"
               height="2.7rem"
               isLoading={isSessionLoading}
@@ -61,7 +63,7 @@ const MainNavigation = () => {
             </Skeleton>
           </li>
           <li>
-            <Skeleton color="rgba(255, 255, 255, 0.08)" width="10rem" isLoading={isSessionLoading}>
+            <Skeleton color={skeletonColor} width="10rem" isLoading={isSessionLoading}>
               {session.status === 'authenticated' ? (
                 <div ref={MyPageTabWrapper}>
                   <Styled.MyPageButton

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -9,17 +9,18 @@ export const Nav = styled.nav`
 
 interface NavListProps {
   currentPage: string;
+  isSessionLoading: boolean;
 }
 
 export const NavList = styled.ul<NavListProps>`
-  ${({ theme, currentPage }) => css`
+  ${({ theme, currentPage, isSessionLoading }) => css`
     display: flex;
     align-items: center;
     height: 2.7rem;
 
     & > li {
       ${theme.fonts.kr.bold18}
-      margin: 0 2rem;
+      margin: 0 ${isSessionLoading ? '1rem' : '2rem'};
 
       &:first-of-type {
         margin-left: 0;
@@ -27,14 +28,12 @@ export const NavList = styled.ul<NavListProps>`
       &:nth-of-type(2) {
         display: flex;
         align-items: center;
-        margin-right: 0;
         svg {
           margin-left: 4rem;
         }
       }
       &:last-of-type {
         margin-right: 0;
-        margin-left: 4rem;
       }
 
       & > a {

--- a/src/components/common/Skeleton/Skeleton.component.tsx
+++ b/src/components/common/Skeleton/Skeleton.component.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+import * as Styled from './Skeleton.styled';
+
+interface SkeletonProps {
+  width?: string;
+  height?: string;
+  borderRadius?: number;
+  color: string;
+  isLoading: boolean;
+  children?: ReactNode;
+}
+
+const Skeleton = ({
+  width = 'auto',
+  height = 'auto',
+  borderRadius,
+  color,
+  isLoading,
+  children,
+}: SkeletonProps) => {
+  if (!children)
+    return isLoading ? (
+      <Styled.Skeleton
+        width={width}
+        height={height}
+        borderRadius={borderRadius}
+        isLoading={isLoading}
+        color={color}
+      />
+    ) : null;
+
+  return isLoading ? (
+    <Styled.Skeleton
+      width={width}
+      height={height}
+      borderRadius={borderRadius}
+      isLoading={isLoading}
+      color={color}
+    >
+      {children}
+    </Styled.Skeleton>
+  ) : (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>{children}</>
+  );
+};
+
+export default Skeleton;

--- a/src/components/common/Skeleton/Skeleton.styled.ts
+++ b/src/components/common/Skeleton/Skeleton.styled.ts
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface SkeletonProps {
+  width: string;
+  height: string;
+  borderRadius?: number;
+  color: string;
+  isLoading: boolean;
+}
+
+export const Skeleton = styled.div<SkeletonProps>`
+  ${({ width, height, borderRadius, color, isLoading }) => css`
+    @keyframes fade {
+      from {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    display: inline-block;
+    width: ${width};
+    height: ${height};
+    background: ${color};
+    border-radius: ${borderRadius ?? '1rem'};
+    animation: 0.6s linear infinite fade;
+
+    & * {
+      opacity: ${isLoading ? 0 : 1};
+    }
+  `}
+`;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -15,3 +15,4 @@ export { default as Accordion } from './Accordion/Accordion.component';
 export { default as MyPageTab } from './MyPageTab/MyPageTab.component';
 export { default as BulletedList } from './BulletedList/BulletedList.component';
 export { default as LoadingModal } from './LoadingModal/LoadingModal.component';
+export { default as Skeleton } from './Skeleton/Skeleton.component';


### PR DESCRIPTION
## 변경사항

- common하게 사용되는 Skeleton component를 구현했습니다. 사용법은 2가지로 나뉩니다.
  - Skeleton 단독 사용
  ```tsx
  <Skeleton color='black' width="10rem" height="5rem" isLoading={isLoading} />
  ```
  이때는 width와 height를 필수적으로 명시해줘야합니다.

  - Skeleton 내부에 children을 사용
  ```tsx
  <Skeleton color="gray" isLoading={isLoading}>
    <span>ABCDEFG</span>
  </Skeleton>
  ```
  이때는 width와 height를 명시해주지 않으면 children의 width와 height값으로 스켈레톤이 그려집니다. children의 width와 height를 기준으로 스켈레톤을 그리고 싶지 않다면 width, height prop에 값을 전달하면 됩니다.

- MainNavigation 컴포넌트에서 session값을 loading중일때 Skeleton UI가 노출되게끔 해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
