### PR TITLE
Recruit(팀 상세)공고 페이지에서 mobile 뷰포트일때 채널톡 버튼을 숨겨준다.

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,3 @@
 next.config.js
 .storybook/*.js
+ChannelService.js

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,11 @@
 import type { AppProps } from 'next/app';
 import { css, Global, ThemeProvider } from '@emotion/react';
 import { globalStyles, theme } from '@/styles';
-import { GlobalSEO, Layout, LoadingModal } from '@/components';
+import { ChannelTalk, GlobalSEO, Layout, LoadingModal } from '@/components';
 import { SessionProvider } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { HOME_PAGE } from '@/constants';
-import ChannelService from '@/utils/services/ChannelService';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const [isRouteChange, setIsRouteChange] = useState(false);
@@ -19,11 +18,6 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     router.events.on('routeChangeStart', handleShowLoadingSpinner);
     router.events.on('routeChangeComplete', handleHideLoadingSpinner);
     router.events.on('routeChangeError', handleHideLoadingSpinner);
-
-    const channelServiceInstance = new ChannelService();
-    channelServiceInstance.boot({
-      pluginKey: process.env.NEXT_PUBLIC_CHANNEL_PLUGIN,
-    });
 
     return () => {
       router.events.off('routeChangeStart', handleShowLoadingSpinner);
@@ -50,6 +44,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
         <ThemeProvider theme={theme}>
           <Layout>
             <Component {...pageProps} />
+            <ChannelTalk />
             {isRouteChange && <LoadingModal setIsOpenModal={setIsRouteChange} />}
           </Layout>
         </ThemeProvider>

--- a/src/components/common/ChannelTalk/ChannelTalk.component.tsx
+++ b/src/components/common/ChannelTalk/ChannelTalk.component.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import ChannelService from '@/utils/services/ChannelService';
+import { useDetectViewPort } from '@/hooks';
+import { useRouter } from 'next/router';
+import { PATH_NAME } from '@/constants';
+
+const ChannelTalk = () => {
+  const [channelServiceInstance, setChannelServiceInstance] = useState<any>(null);
+  const router = useRouter();
+  const { size } = useDetectViewPort();
+
+  useEffect(() => {
+    setChannelServiceInstance(new ChannelService());
+  }, []);
+
+  useEffect(() => {
+    channelServiceInstance?.boot({
+      pluginKey: process.env.NEXT_PUBLIC_CHANNEL_PLUGIN,
+    });
+  }, [channelServiceInstance]);
+
+  useEffect(() => {
+    if (router.pathname === PATH_NAME.RECRUIT_PAGE && size === 'mobile') {
+      channelServiceInstance?.hideChannelButton();
+    } else {
+      channelServiceInstance?.showChannelButton();
+    }
+  }, [channelServiceInstance, router.pathname, size]);
+
+  return null;
+};
+
+export default ChannelTalk;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -19,3 +19,4 @@ export { default as InAppSignInDialog } from './InAppSignInDialog/InAppSignInDia
 export { default as SignInModal } from './SignInModal/SignInModal.component';
 export { default as Skeleton } from './Skeleton/Skeleton.component';
 export { default as Lottie } from './Lottie/Lottie.component';
+export { default as ChannelTalk } from './ChannelTalk/ChannelTalk.component';

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -35,4 +35,5 @@ export const PATH_NAME = {
   MY_PAGE_ACCOUNT: '/my-page/account',
   MY_PAGE_APPLY_STATUS: '/my-page/apply-status',
   MY_PAGE_APPLICATION_DETAIL: '/my-page/application-detail/[applicationId]',
+  RECRUIT_PAGE: '/recruit/[platformName]',
 };

--- a/src/utils/services/ChannelService.js
+++ b/src/utils/services/ChannelService.js
@@ -56,6 +56,14 @@ class ChannelService {
   shutdown() {
     window.ChannelIO('shutdown');
   }
+
+  showChannelButton() {
+    window.ChannelIO('showChannelButton');
+  }
+
+  hideChannelButton() {
+    window.ChannelIO('hideChannelButton');
+  }
 }
 
 export default ChannelService;


### PR DESCRIPTION
## 변경사항

- 채널톡을 하나의 함수 컴포넌트로 정의한 후 내부에서 useEffect를 사용하여 Next의 ServerSide에서는 코드가 작동하지 않게 처리해주었습니다.
- router.path과 useDetectViewport훅을 사용하여 Recruit페이지에서 mobile 뷰포트일때만 채널톡 버튼을 숨김처리 해주었습니다.
- commit시 stylelint가 ChannelService.js 파일을 검사하여 에러를 발생시켜 ignore처리 해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
