### PR TITLE
서류 제출 후 검토중 UI가 보여질때를 면접결과 발표 -> 모집중으로 변경

### DIFF
--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -17,7 +17,7 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
 
   if (
     submittedApplication.result.status === 'SUBMITTED' &&
-    recruitingProgressStatus === 'AFTER-SCREENING-ANNOUNCED'
+    recruitingProgressStatus === 'IN-RECRUITING'
   )
     return (
       <Styled.StatusDetail>


### PR DESCRIPTION
## 변경사항

- 서류 제출 후 검토중 UI가 보여지는 조건식이 잘못 설정되어있었어서 변경해주었습니다. 모집중에 보여지는게 맞는데 기존에 서류 결과 발표 후 보여지게끔 설정되어 있었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
