### PR TITLE
목록으로 돌아가기 버튼 UI 변경 및 link 변경

### DIFF
--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -439,7 +439,10 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
               </Styled.SubmitButton>
             </>
           )}
-          <Styled.BackToListLink href={HOME_PAGE}>목록으로 돌아가기</Styled.BackToListLink>
+          <Styled.BackToListLink href={`/recruit/${application.team.name.toLowerCase()}`}>
+            <Styled.ChevronLeft />
+            목록으로 돌아가기
+          </Styled.BackToListLink>
         </Styled.ControlSection>
       </form>
       {isOpenTempSaveSuccessAlertModal && (

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -1,6 +1,7 @@
 import LinkTo from '@/components/common/LinkTo/LinkTo.component';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import ChevronRight7 from '@/assets/svg/chevron-right-7.svg';
 
 export const PersonalInformationSection = styled.section`
   margin-top: 6rem;
@@ -91,14 +92,15 @@ export const SubmittedCompletedButton = styled.button`
 
 export const BackToListLink = styled(LinkTo)`
   ${({ theme }) => css`
-    ${theme.button.type.defaultLine}
-    display: inline-block;
-    width: 100%;
-    margin-top: 1.6rem;
-    text-align: center;
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      margin-top: 6rem;
-    }
+    ${theme.fonts.kr.medium16};
+    display: inline-flex;
+    align-items: center;
+    margin-top: 4rem;
   `}
+`;
+
+export const ChevronLeft = styled(ChevronRight7)`
+  margin-right: 1.1rem;
+  margin-left: 1rem;
+  transform: rotate(180deg);
 `;


### PR DESCRIPTION
## 변경사항

- 지원서 작성 페이지와 지원서 상세 페이지에서 목록으로 돌아가기 버튼에 대한 UI가 변경되어 반영해주었습니다.
- 목록으로 돌아가기 버튼이 기존에는 HOME_PAGE로 가게끔 설정해놓았었는데 기획서가 생기며 작성중이던 플랫폼의 모집공고로 돌아가게끔 변경해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
