### PR TITLE
임시저장하기, 제출하기 이후 지원현황으로 이동하게끔 수정

### DIFF
--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -7,7 +7,7 @@ import {
   LabeledTextArea,
   LoadingModal,
 } from '@/components';
-import { HOME_PAGE, MY_PAGE_APPLICATION_DETAIL, PATH_NAME } from '@/constants';
+import { HOME_PAGE, MY_PAGE_APPLY_STATUS, PATH_NAME } from '@/constants';
 import { usePreventPageChange } from '@/hooks';
 import { ValueOf } from '@/types';
 import { Application } from '@/types/dto';
@@ -447,12 +447,14 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
           beforeRef={tempSaveButtonRef}
           heading="임시 저장 완료!"
           paragraph="기간 내에 지원서는 꼭! 잊지말고 제출해주세요!"
-          handleApprovalButton={() =>
-            handleCloseTempSaveAlertModal(setIsOpenTempSaveSuccessAlertModal)
-          }
+          handleApprovalButton={() => {
+            router.push(MY_PAGE_APPLY_STATUS);
+            handleCloseTempSaveAlertModal(setIsOpenTempSaveSuccessAlertModal);
+          }}
           setIsOpenModal={setIsOpenTempSaveSuccessAlertModal}
           deemClose={false}
           escClose={false}
+          enterClose={false}
         />
       )}
       {isOpenTempSaveFailedAlertModal && (
@@ -484,13 +486,13 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
       {isOpenSuccessSubmittedModal && (
         <ConfirmModalDialog
           heading="지원서 제출 완료!"
-          paragraph="귀한 시간내어 매쉬업 12기에 지원해주셔서 진심으로 감사드립니다! 3월 19일에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
+          paragraph="귀한 시간내어 매쉬업 12기에 지원해주셔서 진심으로 감사드립니다! 4월 2일(토) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
           approvalButtonMessage="내 지원서 확인하기"
           cancelButtonMessage="홈으로"
           setIsOpenModal={setIsOpenSuccessSubmittedModal}
           handleCancelButton={() => router.push(HOME_PAGE)}
           handleApprovalButton={() => {
-            router.push(`${MY_PAGE_APPLICATION_DETAIL}/${application.applicationId}`);
+            router.push(MY_PAGE_APPLY_STATUS);
             setIsTempSaved(true);
             setIsOpenSuccessSubmittedModal(false);
           }}


### PR DESCRIPTION
## 변경사항

- 기존에 임시저장하기를 누른 후 alert이 뜨고 확인 버튼을 눌렀을때 아무 액션이 일어나지 않았는데 지원 현황 페이지로 이동하게끔 변경하였습니다.
- 제출하기 이후 내 지원서 확인 버튼을 누르면 지원서 상세 페이지로 이동했었는데 지원현황 페이지로 이동하게끔 변경하였습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정
- 문서 업데이트
- 배포 관련
- 프로젝트 설정(웹팩, 바벨, 린팅 등)
- 패키지 추가 및 버전 변경
- 모집 기간 변경에 따른 제출 이후 나오는 다이얼로그의 워딩을 수정해주었습니다.

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
