### PR TITLE
중복제출 불가 알림 다이얼로그 수정

### DIFF
--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -65,6 +65,8 @@ const ApplyLayout = ({ heading, role, application, isSubmitted }: ApplyLayoutPro
           setIsOpenModal={setIsOpenAlreadySubmittedModal}
           handleApprovalButton={() => setIsOpenAlreadySubmittedModal(false)}
           handleCancelButton={() => router.push(MY_PAGE_APPLY_STATUS)}
+          deemClose={false}
+          escClose={false}
         />
       )}
       {isOpenTempSavedModal && !isSubmitted && (

--- a/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
+++ b/src/components/apply/ApplyLayout/ApplyLayout.component.tsx
@@ -1,4 +1,4 @@
-import { AlertModalDialog, ApplyForm } from '@/components';
+import { AlertModalDialog, ApplyForm, ConfirmModalDialog } from '@/components';
 import {
   APPLY_ANDROID_PAGE,
   APPLY_DESIGN_PAGE,
@@ -6,8 +6,10 @@ import {
   APPLY_IOS_PAGE,
   APPLY_NODE_PAGE,
   APPLY_SPRING_PAGE,
+  MY_PAGE_APPLY_STATUS,
 } from '@/constants';
 import { Application } from '@/types/dto';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import * as Styled from './ApplyLayout.styled';
 
@@ -43,6 +45,7 @@ const ApplyLayout = ({ heading, role, application, isSubmitted }: ApplyLayoutPro
   const [isOpenTempSavedModal, setIsOpenTempSavedModal] = useState(
     application.status === 'WRITING',
   );
+  const router = useRouter();
   return (
     <>
       <Styled.Layout>
@@ -54,11 +57,14 @@ const ApplyLayout = ({ heading, role, application, isSubmitted }: ApplyLayoutPro
         </section>
       </Styled.Layout>
       {isOpenAlreadySubmittedModal && (
-        <AlertModalDialog
-          heading="이미 제출한 지원서가 존재합니다."
-          paragraph="이미 한 번 지원서를 제출하셨다면 이제 또 다른 지원서는 제출하지 못합니다."
+        <ConfirmModalDialog
+          heading="제출한 지원서가 있어서 구경만 가능해요!"
+          paragraph="중복 지원은 불가해서 추가적인 지원서 제출은 불가해요. 팀 지원서들은 전부 구경 가능하답니다."
+          approvalButtonMessage="확인"
+          cancelButtonMessage="지원현황으로 갈래요"
           setIsOpenModal={setIsOpenAlreadySubmittedModal}
           handleApprovalButton={() => setIsOpenAlreadySubmittedModal(false)}
+          handleCancelButton={() => router.push(MY_PAGE_APPLY_STATUS)}
         />
       )}
       {isOpenTempSavedModal && !isSubmitted && (


### PR DESCRIPTION
## 변경사항

- 이미 제출한 지원서가 있을때 지원서 작성 페이지에 접근시 노출되는 다이얼로그를 Alert에서 Confirm으로 변경해주었습니다.
- 내부 워딩도 변경해주었고 지원현황으로 가기와 페이지에 머무르는 동작인 확인 버튼으로 나누어주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
