### PR TITLE
server side에서 api요청중 에러가 나면 이동 할 페이지 정의 및 리다이렉트 기능 구현

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { css } from '@emotion/react';
 import LinkTo from '@/components/common/LinkTo/LinkTo.component';
 import { HOME_PAGE } from '@/constants';
+import { useDetectViewPort } from '@/hooks';
 
 const StyledNotFound = styled.div`
   display: flex;
@@ -19,6 +20,11 @@ const StyledParagraph = styled.p`
     margin: 3.6rem 0;
     color: ${theme.colors.gray80};
     letter-spacing: -0.08rem;
+
+    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+      ${theme.fonts.kr.medium15};
+      margin: 2rem 0 5rem;
+    }
   `}
 `;
 
@@ -32,9 +38,15 @@ const StyledToHomeLink = styled(LinkTo)`
 `;
 
 const NotFound = () => {
+  const { size } = useDetectViewPort();
   return (
     <StyledNotFound>
-      <Image src={debuging.src} width={debuging.width / 2} height={debuging.height / 2} alt="" />
+      <Image
+        src={debuging.src}
+        width={size === 'mobile' || size === 'tablet_s' ? 160 : 240}
+        height={size === 'mobile' || size === 'tablet_s' ? 160 : 240}
+        alt=""
+      />
       <StyledParagraph>요청한.. 페이지가.. 없..다.. 왜지..?</StyledParagraph>
       <StyledToHomeLink href={HOME_PAGE}>Mash-Up 리크루팅 홈페이지로 호다닥</StyledToHomeLink>
     </StyledNotFound>

--- a/pages/error.tsx
+++ b/pages/error.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import debuging from '@/assets/images/debuging-2x.png';
+import Image from 'next/image';
+import { css } from '@emotion/react';
+import LinkTo from '@/components/common/LinkTo/LinkTo.component';
+import { HOME_PAGE } from '@/constants';
+import { useDetectViewPort } from '@/hooks';
+
+const StyledErrorPage = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledParagraph = styled.p`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold22};
+    margin: 3.6rem 0;
+    color: ${theme.colors.gray80};
+    letter-spacing: -0.08rem;
+    white-space: pre-wrap;
+    text-align: center;
+
+    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+      ${theme.fonts.kr.medium15};
+      margin: 2rem 0 5rem;
+    }
+  `}
+`;
+
+const StyledToHomeLink = styled(LinkTo)`
+  ${({ theme }) => css`
+    ${theme.button.type.primary};
+    display: inline-block;
+    padding: 1.6rem 2rem;
+    letter-spacing: -0.08rem;
+  `}
+`;
+
+const Error = () => {
+  const { size } = useDetectViewPort();
+  return (
+    <StyledErrorPage>
+      <Image
+        src={debuging.src}
+        width={size === 'mobile' || size === 'tablet_s' ? 160 : 240}
+        height={size === 'mobile' || size === 'tablet_s' ? 160 : 240}
+        alt=""
+      />
+      <StyledParagraph>
+        {'알 수 없는 에러가.. 발생..했다..\n에러가 자꾸 나면.. 채널톡으로 문의해죠....!'}
+      </StyledParagraph>
+      <StyledToHomeLink href={HOME_PAGE}>Mash-Up 리크루팅 홈페이지로 호다닥</StyledToHomeLink>
+    </StyledErrorPage>
+  );
+};
+
+export default Error;

--- a/pages/my-page/account.tsx
+++ b/pages/my-page/account.tsx
@@ -1,6 +1,6 @@
 import { applicantApiService } from '@/api/services';
 import { AccountLayout } from '@/components';
-import { HOME_PAGE } from '@/constants';
+import { ERROR_PAGE, HOME_PAGE } from '@/constants';
 import { Applicant } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -23,17 +23,20 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const response = await applicantApiService.getMyApplicantData({
-    accessToken: session.accessToken,
-  });
+  try {
+    const applicantRes = await applicantApiService.getMyApplicantData({
+      accessToken: session.accessToken,
+    });
 
-  if (response.code !== 'SUCCESS') {
+    const userInfo = applicantRes.data;
+
+    return { props: { userInfo } };
+  } catch (error) {
     return {
-      redirect: { destination: HOME_PAGE, permanent: false },
+      redirect: {
+        permanent: false,
+        destination: ERROR_PAGE,
+      },
     };
   }
-
-  const userInfo = response.data;
-
-  return { props: { userInfo } };
 };

--- a/pages/my-page/application-detail/[applicationId].tsx
+++ b/pages/my-page/application-detail/[applicationId].tsx
@@ -1,5 +1,6 @@
 import { applicationApiService } from '@/api/services';
 import { ApplicationDetailLayout } from '@/components';
+import { ERROR_PAGE, HOME_PAGE } from '@/constants';
 import { Application } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -25,42 +26,40 @@ export const getServerSideProps: GetServerSideProps<ApplicationDetailProps> = as
     };
   }
 
-  const applicationsRes = await applicationApiService.getApplications({
-    accessToken: session?.accessToken,
-  });
+  try {
+    const applicationsRes = await applicationApiService.getApplications({
+      accessToken: session?.accessToken,
+    });
 
-  // TODO:(하준) API 실패 응답시 띄워 줄 UI나 동작이 정의되면 변경
-  if (applicationsRes.code !== 'SUCCESS')
+    const applications = applicationsRes.data;
+
+    const isSubmitted = applications.some(({ status }) => status === 'SUBMITTED');
+
+    const application = applications.find(
+      ({ applicationId }) =>
+        applicationId === parseInt(context.params?.applicationId as string, 10),
+    );
+
+    if (!application) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: HOME_PAGE,
+        },
+      };
+    }
+
     return {
-      redirect: {
-        permanent: false,
-        destination: '/',
+      props: {
+        application,
+        isSubmitted,
       },
     };
-
-  const applications = applicationsRes.data;
-
-  const isSubmitted = applications.some(({ status }) => status === 'SUBMITTED');
-
-  const application = applications.find(
-    ({ applicationId }) => applicationId === parseInt(context.params?.applicationId as string, 10),
-  );
-
-  if (!application) {
+  } catch (error) {
     return {
-      redirect: {
-        permanent: false,
-        destination: '/',
-      },
+      redirect: { destination: ERROR_PAGE, permanent: false },
     };
   }
-
-  return {
-    props: {
-      application,
-      isSubmitted,
-    },
-  };
 };
 
 export default ApplicationDetail;

--- a/pages/my-page/apply-status.tsx
+++ b/pages/my-page/apply-status.tsx
@@ -1,6 +1,6 @@
 import { applicationApiService } from '@/api/services';
 import { ApplyStatusLayout } from '@/components';
-import { HOME_PAGE } from '@/constants';
+import { ERROR_PAGE, HOME_PAGE } from '@/constants';
 import { Application } from '@/types/dto';
 import {
   getRecruitingProgressStatusFromRecruitingPeriod,
@@ -45,7 +45,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return { props: { applications, recruitingProgressStatus } };
   } catch (error) {
     return {
-      redirect: { destination: HOME_PAGE, permanent: false },
+      redirect: { destination: ERROR_PAGE, permanent: false },
     };
   }
 };

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -1,5 +1,8 @@
 import { teamUrls } from './team';
 
+export const NOT_FOUND_PAGE = '/not-found';
+export const ERROR_PAGE = '/error';
+
 export const HOME_PAGE = '/';
 export const RECRUIT_DETAILS_ID = 'recruit-details';
 


### PR DESCRIPTION
## 변경사항

- server side에서 api 요청 중 에러가 발생하면 이동 할 error페이지 컴포넌트를 추가했습니다.
- server side에서 api요청하는 코드를 try문으로 감싸준 후 catch문에서 error페이지로 리다이렉트 시켜줬습니다.
- error페이지와 404페이지의 디자인이 같은데 error페이지가 나오며 반응형 디자인이 추가되어 404페이지에도 적용해줬습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
