### PR TITLE
데스크탑 뷰에서의 헤더 컨텐츠 너비 수정

### DIFF
--- a/src/components/common/Header/Header.styled.ts
+++ b/src/components/common/Header/Header.styled.ts
@@ -26,7 +26,7 @@ export const HeaderInner = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  max-width: 120rem;
+  max-width: 124rem;
   margin: 0 auto;
   padding: 0 2rem;
 `;


### PR DESCRIPTION
## 변경사항

<table>
    <tr align="center">
        <td><B>기존<B></td>
        <td><B>수정 후<B></td>
    </tr>
    <tr align="center">
        <td>
            <img src="https://user-images.githubusercontent.com/37530109/158310027-2c996cbe-e306-4cc2-b8d9-d389e03876b6.png">
        </td>
        <td>
            <img src="https://user-images.githubusercontent.com/37530109/158310024-7b9d148c-22d2-4e5d-8085-45c19346843a.png">
        </td>
    </tr>
</table>

- 데스크탑 뷰에서의 헤더 컨텐츠 width가 padding 포함 1200으로 되어 있어 1240으로 변경해주었습니다!

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
