### PR TITLE
Toast 컴포넌트 리팩터링

### DIFF
--- a/src/components/common/InAppSignInDialog/InAppSignInDialog.component.tsx
+++ b/src/components/common/InAppSignInDialog/InAppSignInDialog.component.tsx
@@ -14,21 +14,24 @@ const browserNameMap: Record<InAppBrowser, string> = {
 } as const;
 
 export interface InAppSignInDialogProps {
-  handleSuccessCopy: () => void;
-  handleCloseButton: () => void;
+  handleCloseDialog: () => void;
 }
 
-const InAppSignInDialog = ({ handleSuccessCopy, handleCloseButton }: InAppSignInDialogProps) => {
+const InAppSignInDialog = ({ handleCloseDialog }: InAppSignInDialogProps) => {
   const browserName = browserNameMap[getInAppBrowser(window.navigator) as InAppBrowser];
   const toast = useToast();
   const { copy } = useCopyToClipboard(TARGET_URL, {
     onSuccess: () => {
-      toast({ text: '링크 복사 완료!', status: 'success' });
-      handleSuccessCopy();
+      toast({ content: '링크 복사 완료!', status: 'success' });
     },
     onError: () => {
-      toast({ text: '링크 복사 실패. 다시 시도해주세요!', status: 'error' });
+      toast({
+        content: <span style={{ textDecoration: 'underline' }}>{TARGET_URL}</span>,
+        status: 'error',
+        persist: true,
+      });
     },
+    onComplete: handleCloseDialog,
   });
 
   return (
@@ -44,7 +47,7 @@ const InAppSignInDialog = ({ handleSuccessCopy, handleCloseButton }: InAppSignIn
           <div />
           링크 복사
         </Styled.LinkCopyButton>
-        <Styled.CloseButton type="button" onClick={handleCloseButton}>
+        <Styled.CloseButton type="button" onClick={handleCloseDialog}>
           <div />
           확인
         </Styled.CloseButton>

--- a/src/components/common/SignInModal/SignInModal.component.tsx
+++ b/src/components/common/SignInModal/SignInModal.component.tsx
@@ -19,10 +19,7 @@ const SignInModal = ({ beforeRef, setIsOpenModal, type, callbackUrl }: SignInMod
   return (
     <Modal beforeRef={beforeRef} setIsOpenModal={setIsOpenModal}>
       {isInAppBrowser ? (
-        <InAppSignInDialog
-          handleSuccessCopy={handleCloseModal}
-          handleCloseButton={handleCloseModal}
-        />
+        <InAppSignInDialog handleCloseDialog={handleCloseModal} />
       ) : (
         <SignInDialog type={type} handleCloseButton={handleCloseModal} callbackUrl={callbackUrl} />
       )}

--- a/src/components/common/Toast/Toast.component.tsx
+++ b/src/components/common/Toast/Toast.component.tsx
@@ -27,6 +27,7 @@ export interface ToastOptions {
   position: ToastPosition;
   requestClose?: boolean;
   status: Status;
+  persist?: boolean;
 }
 
 export type ToastState = Record<ToastPosition, ToastOptions[]>;
@@ -39,16 +40,22 @@ export const ToastContainer = ({
   onRequestRemove,
   requestClose = false,
   duration,
+  persist,
 }: ToastContainerProps) => {
   useEffect(() => {
-    const timerId = setTimeout(() => {
-      onRequestRemove();
-    }, duration);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    if (!persist) {
+      timeoutId = setTimeout(() => {
+        onRequestRemove();
+      }, duration);
+    }
 
     return () => {
-      clearTimeout(timerId);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     };
-  }, [duration, onRequestRemove]);
+  }, [duration, onRequestRemove, persist]);
 
   useEffect(() => {
     if (requestClose) {
@@ -62,15 +69,15 @@ export const ToastContainer = ({
 interface ToastProps
   extends RenderProps,
     Partial<Pick<ToastOptions, 'duration' | 'position' | 'status'>> {
-  text?: string;
+  content?: ReactNode;
 }
 
-const Toast = ({ text, onClose, status = 'success' }: ToastProps) => {
+const Toast = ({ content, onClose, status = 'success' }: ToastProps) => {
   return (
     <Styled.Toast status={status}>
       <Styled.Contents>
         <Styled.Badge>{status === 'success' ? <SuccessBadge /> : <ErrorBadge />}</Styled.Badge>
-        <Styled.Text>{text}</Styled.Text>
+        <Styled.Text>{content}</Styled.Text>
       </Styled.Contents>
       <Styled.CloseButton onClick={onClose}>
         {status === 'success' ? <SuccessClose /> : <ErrorClose />}

--- a/src/components/common/Toast/ToastManager.tsx
+++ b/src/components/common/Toast/ToastManager.tsx
@@ -10,7 +10,7 @@ import {
   ToastContainer,
 } from './Toast.component';
 
-type CreateToastOptions = Partial<Pick<ToastOptions, 'duration' | 'position' | 'id'>>;
+type CreateToastOptions = Partial<Pick<ToastOptions, 'duration' | 'position' | 'id' | 'persist'>>;
 
 export interface ToastMethods {
   // eslint-disable-next-line no-unused-vars
@@ -95,6 +95,7 @@ export class ToastManager extends Component<ToastManagerProps, ToastState> {
       message,
       position,
       duration: options.duration,
+      persist: options.persist,
       onRequestRemove: () => this.removeToast(id, position),
       requestClose: false,
     };

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -4,14 +4,15 @@ import { copyToClipboard } from '@/utils/clipboard';
 export interface UseCopyToClipboardOptions {
   onSuccess?: () => void;
   onError?: () => void;
+  onComplete?: () => void;
 }
 
 const useCopyToClipboard = (text: string, options: UseCopyToClipboardOptions = {}) => {
-  const { onSuccess, onError } = options;
+  const { onSuccess, onError, onComplete } = options;
 
   const copy = useCallback(() => {
-    copyToClipboard(text).then(onSuccess).catch(onError);
-  }, [text, onSuccess, onError]);
+    copyToClipboard(text).then(onSuccess).catch(onError).finally(onComplete);
+  }, [text, onSuccess, onError, onComplete]);
   return { copy };
 };
 export default useCopyToClipboard;

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -9,13 +9,15 @@ import {
   ToastPosition,
 } from '@/components/common/Toast/Toast.component';
 import { toast } from '@/components/common/Toast/Toaster';
+import { ReactNode } from 'react';
 
 export interface UseToastOptions {
   position?: ToastPosition;
   duration?: ToastOptions['duration'];
-  text?: string;
+  content?: ReactNode;
   id?: ToastId;
   status?: Status;
+  persist?: boolean;
 }
 
 const defaults = {


### PR DESCRIPTION
## 변경사항
![스크린샷 2022-03-17 오전 8 18 55](https://user-images.githubusercontent.com/37530109/158708208-4aa72c5b-90f0-46a6-bd47-9a72161727e6.png)

- Toast 옵션 중 persist라는 프로퍼티를 추가하여 한 번 열리면 사용자가 닫기 버튼을 누르기 이전까지는 닫히지 않을 수 있게끔 동작하는 것도 가능하게 하였습니다.
- Toast의 내용을 string에 한정시키는 대신 ReactNode로 설정하여 다른 컴포넌트나 jsx를 주입받을 수 있게끔 하였습니다.
- 링크 복사 실패 시 다시 시도하라는 안내 문구 대신 링크 텍스트를 띄우게끔 하였습니다. 따라서 링크 복사 실패 시에도 Dialog가 닫힐 수 있게끔 대응하였습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
