### PR TITLE
Refactor/mobile hover disable

### DIFF
--- a/src/components/account/AccountManagement/AccountManagement.styled.ts
+++ b/src/components/account/AccountManagement/AccountManagement.styled.ts
@@ -136,6 +136,10 @@ export const SignOutButton = styled.button`
       }
     }
 
+    &:active {
+      background: ${theme.colors.gray10};
+    }
+
     @media (max-width: ${theme.breakPoint.media.tabletS}) {
       ${theme.fonts.kr.bold16};
       position: absolute;

--- a/src/components/account/AccountManagement/AccountManagement.styled.ts
+++ b/src/components/account/AccountManagement/AccountManagement.styled.ts
@@ -130,8 +130,10 @@ export const SignOutButton = styled.button`
     border: 0;
     border-radius: 1rem;
 
-    &:hover {
-      background: ${theme.colors.gray10};
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+      }
     }
 
     @media (max-width: ${theme.breakPoint.media.tabletS}) {

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -102,8 +102,10 @@ export const BackToListLink = styled(LinkTo)`
       vertical-align: middle;
     }
 
-    &:hover {
-      background: ${theme.colors.gray10};
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+      }
     }
   `}
 `;

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -107,6 +107,10 @@ export const BackToListLink = styled(LinkTo)`
         background: ${theme.colors.gray10};
       }
     }
+
+    &:active {
+      background: ${theme.colors.gray10};
+    }
   `}
 `;
 

--- a/src/components/applyStatus/StatusList/StatusList.styled.ts
+++ b/src/components/applyStatus/StatusList/StatusList.styled.ts
@@ -249,6 +249,10 @@ export const ApplicationDetailLink = styled(LinkTo)`
       }
     }
 
+    &:active {
+      background: ${theme.colors.gray40};
+    }
+
     @media (max-width: ${theme.breakPoint.media.tabletS}) {
       ${theme.fonts.kr.bold16};
       width: 100%;

--- a/src/components/applyStatus/StatusList/StatusList.styled.ts
+++ b/src/components/applyStatus/StatusList/StatusList.styled.ts
@@ -243,8 +243,10 @@ export const ApplicationDetailLink = styled(LinkTo)`
     background: ${theme.colors.gray20};
     border-radius: 1.6rem;
 
-    &:hover {
-      background: ${theme.colors.gray40};
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray40};
+      }
     }
 
     @media (max-width: ${theme.breakPoint.media.tabletS}) {

--- a/src/components/common/AlertModalDialog/AlertModalDialog.styled.ts
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.styled.ts
@@ -94,6 +94,18 @@ export const ApprovalButton = styled.button`
       }
     }
 
+    &:active {
+      & > div {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 1.2rem;
+      }
+    }
+
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       ${theme.fonts.kr.medium15};
       padding: 0.85rem 1.6rem;

--- a/src/components/common/AlertModalDialog/AlertModalDialog.styled.ts
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.styled.ts
@@ -80,15 +80,17 @@ export const ApprovalButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
       }
     }
 

--- a/src/components/common/ConfirmModalDialog/ConfirmModalDialog.styled.ts
+++ b/src/components/common/ConfirmModalDialog/ConfirmModalDialog.styled.ts
@@ -89,6 +89,18 @@ export const CancelButton = styled.button`
       }
     }
 
+    &:active {
+      & > div {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 1.2rem;
+      }
+    }
+
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       ${theme.fonts.kr.medium15};
       padding: 0.85rem 1.6rem;
@@ -111,6 +123,18 @@ export const ApprovalButton = styled.button`
 
     @media (hover: hover) {
       &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
+      }
+
+      &:active {
         & > div {
           position: absolute;
           top: 0;

--- a/src/components/common/ConfirmModalDialog/ConfirmModalDialog.styled.ts
+++ b/src/components/common/ConfirmModalDialog/ConfirmModalDialog.styled.ts
@@ -75,15 +75,17 @@ export const CancelButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
       }
     }
 
@@ -107,15 +109,17 @@ export const ApprovalButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
       }
     }
 

--- a/src/components/common/InAppSignInDialog/InAppSignInDialog.styled.ts
+++ b/src/components/common/InAppSignInDialog/InAppSignInDialog.styled.ts
@@ -78,15 +78,17 @@ export const LinkCopyButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
       }
     }
 
@@ -110,15 +112,17 @@ export const CloseButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 1.2rem;
+        }
       }
     }
 

--- a/src/components/common/InAppSignInDialog/InAppSignInDialog.styled.ts
+++ b/src/components/common/InAppSignInDialog/InAppSignInDialog.styled.ts
@@ -92,6 +92,18 @@ export const LinkCopyButton = styled.button`
       }
     }
 
+    &:active {
+      & > div {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 1.2rem;
+      }
+    }
+
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       ${theme.fonts.kr.medium15};
       padding: 0.85rem 1.6rem;
@@ -123,6 +135,18 @@ export const CloseButton = styled.button`
           background: rgba(0, 0, 0, 0.3);
           border-radius: 1.2rem;
         }
+      }
+    }
+
+    &:active {
+      & > div {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 1.2rem;
       }
     }
 

--- a/src/components/common/LabeledInput/LabeledInput.styled.ts
+++ b/src/components/common/LabeledInput/LabeledInput.styled.ts
@@ -29,6 +29,10 @@ export const Input = styled.input<StyledInputProps>`
       }
     }
 
+    &:active {
+      border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+    }
+
     &:focus {
       border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple70};
     }

--- a/src/components/common/LabeledInput/LabeledInput.styled.ts
+++ b/src/components/common/LabeledInput/LabeledInput.styled.ts
@@ -23,8 +23,10 @@ export const Input = styled.input<StyledInputProps>`
       background: ${theme.colors.purple40};
     }
 
-    &:hover {
-      border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+    @media (hover: hover) {
+      &:hover {
+        border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+      }
     }
 
     &:focus {

--- a/src/components/common/LabeledTextArea/LabeledTextArea.styled.ts
+++ b/src/components/common/LabeledTextArea/LabeledTextArea.styled.ts
@@ -29,6 +29,10 @@ export const TextArea = styled.textarea<StyledTextAreaProps>`
       }
     }
 
+    &:active {
+      border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+    }
+
     &:focus {
       border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple70};
     }

--- a/src/components/common/LabeledTextArea/LabeledTextArea.styled.ts
+++ b/src/components/common/LabeledTextArea/LabeledTextArea.styled.ts
@@ -23,8 +23,10 @@ export const TextArea = styled.textarea<StyledTextAreaProps>`
       background: ${theme.colors.purple40};
     }
 
-    &:hover {
-      border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+    @media (hover: hover) {
+      &:hover {
+        border: 0.1rem solid ${isError ? theme.colors.red50 : theme.colors.purple40};
+      }
     }
 
     &:focus {

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -46,6 +46,10 @@ export const NavList = styled.ul<NavListProps>`
           color: ${theme.colors.purple70};
         }
       }
+
+      & > a:active {
+        color: ${theme.colors.purple70};
+      }
     }
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
@@ -89,6 +93,10 @@ export const SignInButton = styled.button<SignInButtonProps>`
       &:hover {
         color: ${theme.colors.purple70};
       }
+    }
+
+    &:active {
+      color: ${theme.colors.purple70};
     }
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
@@ -138,6 +146,14 @@ export const MyPageButton = styled.button<MyPageButtonProps>`
         & > svg > path {
           stroke: ${theme.colors.purple70};
         }
+      }
+    }
+
+    &:active {
+      color: ${theme.colors.purple70};
+
+      & > svg > path {
+        stroke: ${theme.colors.purple70};
       }
     }
 

--- a/src/components/common/MainNavigation/MainNavigation.styled.ts
+++ b/src/components/common/MainNavigation/MainNavigation.styled.ts
@@ -41,8 +41,10 @@ export const NavList = styled.ul<NavListProps>`
         color: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
       }
 
-      & > a:hover {
-        color: ${theme.colors.purple70};
+      @media (hover: hover) {
+        & > a:hover {
+          color: ${theme.colors.purple70};
+        }
       }
     }
 
@@ -83,9 +85,12 @@ export const SignInButton = styled.button<SignInButtonProps>`
     background: transparent;
     border: 0;
 
-    &:hover {
-      color: ${theme.colors.purple70};
+    @media (hover: hover) {
+      &:hover {
+        color: ${theme.colors.purple70};
+      }
     }
+
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       ${theme.fonts.kr.medium15};
     }
@@ -126,11 +131,13 @@ export const MyPageButton = styled.button<MyPageButtonProps>`
       stroke: ${currentPage === HOME_PAGE ? theme.colors.white : theme.colors.gray80};
     }
 
-    &:hover {
-      color: ${theme.colors.purple70};
+    @media (hover: hover) {
+      &:hover {
+        color: ${theme.colors.purple70};
 
-      & > svg > path {
-        stroke: ${theme.colors.purple70};
+        & > svg > path {
+          stroke: ${theme.colors.purple70};
+        }
       }
     }
 

--- a/src/components/common/MyPageTab/MyPageTab.styled.ts
+++ b/src/components/common/MyPageTab/MyPageTab.styled.ts
@@ -87,6 +87,10 @@ export const TabLink = styled(LinkTo, {
         }
       }
 
+      &:active {
+        background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
+      }
+
       & > svg > path {
         stroke: ${isHomePage ? theme.colors.gray10 : theme.colors.gray80};
       }
@@ -120,6 +124,10 @@ export const SignOutButton = styled.button<SignOutButtonProps>`
         &:hover {
           background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
         }
+      }
+
+      &:active {
+        background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
       }
     `;
   }}

--- a/src/components/common/MyPageTab/MyPageTab.styled.ts
+++ b/src/components/common/MyPageTab/MyPageTab.styled.ts
@@ -81,8 +81,10 @@ export const TabLink = styled(LinkTo, {
       border: 0;
       border-radius: 1.2rem;
 
-      &:hover {
-        background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
+      @media (hover: hover) {
+        &:hover {
+          background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
+        }
       }
 
       & > svg > path {
@@ -114,8 +116,10 @@ export const SignOutButton = styled.button<SignOutButtonProps>`
         margin-left: 9.5rem;
       }
 
-      &:hover {
-        background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
+      @media (hover: hover) {
+        &:hover {
+          background: ${isHomePage ? theme.colors.gray90 : theme.colors.gray10};
+        }
       }
     `;
   }}

--- a/src/components/common/SignInDialog/SignInDialog.styled.ts
+++ b/src/components/common/SignInDialog/SignInDialog.styled.ts
@@ -80,15 +80,17 @@ export const CloseButton = styled.button`
     border: 0;
     border-radius: 1.2rem;
 
-    &:hover {
-      & > div {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.1);
-        border-radius: 1.2rem;
+    @media (hover: hover) {
+      &:hover {
+        & > div {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.1);
+          border-radius: 1.2rem;
+        }
       }
     }
 
@@ -129,9 +131,11 @@ export const SignInButton = styled.button`
       left: 2.4rem;
     }
 
-    &:hover {
-      background: ${theme.colors.gray10};
-      border: 0.1rem solid ${theme.colors.gray40};
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+        border: 0.1rem solid ${theme.colors.gray40};
+      }
     }
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {

--- a/src/components/common/SignInDialog/SignInDialog.styled.ts
+++ b/src/components/common/SignInDialog/SignInDialog.styled.ts
@@ -94,6 +94,18 @@ export const CloseButton = styled.button`
       }
     }
 
+    &:active {
+      & > div {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.1);
+        border-radius: 1.2rem;
+      }
+    }
+
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       top: 1rem;
       right: 1rem;
@@ -136,6 +148,11 @@ export const SignInButton = styled.button`
         background: ${theme.colors.gray10};
         border: 0.1rem solid ${theme.colors.gray40};
       }
+    }
+
+    &:active {
+      background: ${theme.colors.gray10};
+      border: 0.1rem solid ${theme.colors.gray40};
     }
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {

--- a/src/components/faq/Navigation/Navigation.styled.ts
+++ b/src/components/faq/Navigation/Navigation.styled.ts
@@ -35,6 +35,11 @@ export const ListItem = styled.li<StyledLiProps>`
       }
     }
 
+    &:active {
+      background: ${theme.colors.gray10};
+      border-radius: 1rem;
+    }
+
     & > a {
       display: block;
       padding: 1.6rem;

--- a/src/components/faq/Navigation/Navigation.styled.ts
+++ b/src/components/faq/Navigation/Navigation.styled.ts
@@ -28,9 +28,11 @@ export const ListItem = styled.li<StyledLiProps>`
       }
     }
 
-    &:hover {
-      background: ${theme.colors.gray10};
-      border-radius: 1rem;
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+        border-radius: 1rem;
+      }
     }
 
     & > a {

--- a/src/components/home/RecruitingDetailNavigation/RecruitingDetailNavigation.styled.ts
+++ b/src/components/home/RecruitingDetailNavigation/RecruitingDetailNavigation.styled.ts
@@ -110,8 +110,10 @@ export const Card = styled.div`
     border-radius: 5rem;
     transition: transform 0.35s ease;
 
-    &:hover {
-      transform: translate(1.2rem, -1.2rem);
+    @media (hover: hover) {
+      &:hover {
+        transform: translate(1.2rem, -1.2rem);
+      }
     }
 
     a {
@@ -132,8 +134,10 @@ export const Card = styled.div`
       height: 20rem;
       padding: 3.6rem;
 
-      &:hover {
-        transform: translate(0.6rem, -0.6rem);
+      @media (hover: hover) {
+        &:hover {
+          transform: translate(0.6rem, -0.6rem);
+        }
       }
 
       button {

--- a/src/components/home/RecruitingDetailNavigation/RecruitingDetailNavigation.styled.ts
+++ b/src/components/home/RecruitingDetailNavigation/RecruitingDetailNavigation.styled.ts
@@ -116,6 +116,10 @@ export const Card = styled.div`
       }
     }
 
+    &:active {
+      transform: translate(1.2rem, -1.2rem);
+    }
+
     a {
       width: 12.1rem;
     }
@@ -138,6 +142,10 @@ export const Card = styled.div`
         &:hover {
           transform: translate(0.6rem, -0.6rem);
         }
+      }
+
+      &:active {
+        transform: translate(0.6rem, -0.6rem);
       }
 
       button {

--- a/src/components/recruit/BottomNavigation/BottomNavigation.styled.ts
+++ b/src/components/recruit/BottomNavigation/BottomNavigation.styled.ts
@@ -33,6 +33,10 @@ export const ListItem = styled.li`
       }
     }
 
+    &:active {
+      background: ${theme.colors.gray10};
+    }
+
     & > a {
       display: flex;
       align-items: center;
@@ -53,6 +57,10 @@ export const ListItem = styled.li`
         & > a:hover {
           background: ${theme.colors.white};
         }
+      }
+
+      & > a:active {
+        background: ${theme.colors.white};
       }
     }
   `}

--- a/src/components/recruit/BottomNavigation/BottomNavigation.styled.ts
+++ b/src/components/recruit/BottomNavigation/BottomNavigation.styled.ts
@@ -27,8 +27,10 @@ export const ListItem = styled.li`
     color: ${theme.colors.gray70};
     border-radius: 1.6rem;
 
-    &:hover {
-      background: ${theme.colors.gray10};
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+      }
     }
 
     & > a {
@@ -47,8 +49,10 @@ export const ListItem = styled.li`
         padding: 0;
       }
 
-      & > a:hover {
-        background: ${theme.colors.white};
+      @media (hover: hover) {
+        & > a:hover {
+          background: ${theme.colors.white};
+        }
       }
     }
   `}

--- a/src/styles/themes/button.ts
+++ b/src/styles/themes/button.ts
@@ -20,6 +20,10 @@ export const button = {
         }
       }
 
+      &:active {
+        background: ${colors.purple80};
+      }
+
       &:disabled {
         background: ${colors.purple40};
       }
@@ -38,6 +42,10 @@ export const button = {
         &:hover {
           background: ${colors.purple20};
         }
+      }
+
+      &:active {
+        background: ${colors.purple20};
       }
 
       &:disabled {
@@ -60,6 +68,10 @@ export const button = {
         &:hover {
           background: ${colors.gray10};
         }
+      }
+
+      &:active {
+        background: ${colors.gray10};
       }
 
       &:disabled {

--- a/src/styles/themes/button.ts
+++ b/src/styles/themes/button.ts
@@ -14,8 +14,10 @@ export const button = {
       border-radius: 1.6rem;
       transition: 0.3s;
 
-      &:hover {
-        background: ${colors.purple80};
+      @media (hover: hover) {
+        &:hover {
+          background: ${colors.purple80};
+        }
       }
 
       &:disabled {
@@ -32,8 +34,10 @@ export const button = {
       border-radius: 1.6rem;
       transition: 0.3s;
 
-      &:hover {
-        background: ${colors.purple20};
+      @media (hover: hover) {
+        &:hover {
+          background: ${colors.purple20};
+        }
       }
 
       &:disabled {
@@ -52,8 +56,10 @@ export const button = {
       border-radius: 1.6rem;
       transition: 0.3s;
 
-      &:hover {
-        background: ${colors.gray10};
+      @media (hover: hover) {
+        &:hover {
+          background: ${colors.gray10};
+        }
       }
 
       &:disabled {


### PR DESCRIPTION
## 변경사항

- 터치로 컨트롤 하는 기기에서는 터치를 한 곳에 마우스 커서가 계속 머무르는식으로 동작하여 아래 첫번째 영상같이 동작하는것을 두번째 영상처럼 변경해주었습니다.

  - 첫번째 영상
https://user-images.githubusercontent.com/71176945/158972547-5bd3bafb-7efc-49b9-b8f1-54f9f66acd04.mp4

  - 두번째 영상
https://user-images.githubusercontent.com/71176945/158972896-ed9f1190-2c97-4a28-9ed7-ced4148f9270.mp4

작업에 대한 레퍼런스는 하단링크의 mdn을 참고했습니다.
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover




### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정
- 문서 업데이트
- 배포 관련
- 프로젝트 설정(웹팩, 바벨, 린팅 등)
- 패키지 추가 및 버전 변경

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
