### PR TITLE
process.env.BASE_URL 동작 이슈 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  env: {
+    BASE_URL: process.env.BASE_URL,
+  },
   // eslint-disable-next-line consistent-return
   async rewrites() {
     return [


### PR DESCRIPTION
## 변경사항

- recruit.mash-up.kr 환경을 감지하기 위해 사용하는 BASE_URL에 NEXT_PUBLIC이 붙어있지 않아 자바스크립트 번들에 포함되지 않는데, 이를 놓쳐서 recruit에 채널톡, GA가 동작하지 않고 있습니다..!
- BASE_URL에 NEXT_PUBLIC을 붙이는 방식으로 해결하게 되면 github actions도 수정해주어야 해서 우선은 next.config.js에 BASE_URL은 자바스크립트 번들에 포함되게끔 명시적으로 [설정](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)해두었습니다..

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
