### PR TITLE
링크드인 인앱 브라우저에서 로그인 불가 알림 추가

### DIFF
--- a/src/components/common/InAppSignInDialog/InAppSignInDialog.component.tsx
+++ b/src/components/common/InAppSignInDialog/InAppSignInDialog.component.tsx
@@ -11,6 +11,7 @@ const browserNameMap: Record<InAppBrowser, string> = {
   NAVER: '네이버',
   CAMPUS_PICK: '캠퍼스픽',
   EVERY_TIME: '에브리타임',
+  LINKEDIN: '링크드인',
 } as const;
 
 export interface InAppSignInDialogProps {

--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -14,6 +14,8 @@ export const getInAppBrowser = (navigator: Navigator) => {
       return 'CAMPUS_PICK';
     case /everytimeApp/i.test(ua):
       return 'EVERY_TIME';
+    case /LinkedInApp/i.test(ua):
+      return 'LINKEDIN';
     default:
       return null;
   }
@@ -26,7 +28,7 @@ const getUserAgentBrowser = (navigator: Navigator) => {
   const android = /(android)/i.test(ua);
 
   switch (true) {
-    case /NAVER|KAKAO|Instagram|\[FB|campuspickApp|everytimeApp/i.test(ua):
+    case /NAVER|KAKAO|Instagram|\[FB|campuspickApp|everytimeApp|LinkedInApp/i.test(ua):
       return 'IN-APP';
     case /CriOS/.test(ua):
       return 'Chrome for iOS';


### PR DESCRIPTION
## 변경사항

- 링크드인 인앱 브라우저에서도 로그인 불가하다는 모달이 띄워지게끔 수정해주었습니다. 
![KakaoTalk_Photo_2022-03-25-03-39-52](https://user-images.githubusercontent.com/71176945/159987631-ce79f11a-5620-4d45-b6c5-fb9b4c499f41.jpeg)


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
