### PR TITLE
모집 종료 이후 서류 검토중이라는 UI가 나오지 않는 이슈 대응

### DIFF
--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -13,17 +13,18 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
     (application) => application.status === 'SUBMITTED',
   );
 
-  if (!submittedApplication) return null;
+  if (!submittedApplication || recruitingProgressStatus === 'AFTER-FIRST-SEMINAR') return null;
 
   if (
-    submittedApplication.result.status === 'SUBMITTED' &&
-    recruitingProgressStatus === 'IN-RECRUITING'
-  )
+    recruitingProgressStatus === 'IN-RECRUITING' ||
+    recruitingProgressStatus === 'END-RECRUITING'
+  ) {
     return (
       <Styled.StatusDetail>
         <ScreeningWait />
       </Styled.StatusDetail>
     );
+  }
 
   return null;
 };


### PR DESCRIPTION
## 변경사항

- 모집 종료 시간 이후 서류 검토중이라는 UI가 나오게끔 조건식이 적혀있지 않아서 조건식을 추가해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
