### PR TITLE
지원서 상세보기에서 목록으로 돌아가기 버튼을 누르면 지원서 목록으로 가게끔 수정

### DIFF
--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -565,7 +565,15 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
               </Styled.SubmitButton>
             </>
           )}
-          <Styled.BackToListLink href={`/recruit/${application.team.name.toLowerCase()}`}>
+          <Styled.BackToListLink
+            href={
+              router.pathname === PATH_NAME.APPLY_PAGE
+                ? `/recruit/${application.team.name.toLowerCase()}`
+                : router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL
+                ? MY_PAGE_APPLY_STATUS
+                : HOME_PAGE
+            }
+          >
             <Styled.ChevronLeft />
             <span>목록으로 돌아가기</span>
           </Styled.BackToListLink>


### PR DESCRIPTION
Changes to be committed:
modified:   src/components/apply/ApplyForm/ApplyForm.component.tsx

## 변경사항

- 기존엔 지원서 상세보기 페이지에서 목록으로 돌아가기 버튼을 누를 시 팀 소개 글로 이동되고 있는 기능을 지원 현황 페이지로 이동하게끔 변경해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
