### PR TITLE
서류 발표 지연에 따른 1회성 모달 다이얼로그 기능 추가

### DIFF
--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -9,11 +9,13 @@ import {
   FinalConfirmAccept,
   FinalConfirmReject,
 } from '@/components';
+import { AlertModalDialog } from '@/components/common';
 import { Application } from '@/types/dto';
 import { RecruitingProgressStatus } from '@/utils/date';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as Styled from './ApplyStatusDetail.styled';
 
+const IS_FIRST_VISIT = 'isFirstVisit';
 interface ApplyStatusDetailProps {
   applications: Application[];
   recruitingProgressStatus: RecruitingProgressStatus;
@@ -23,6 +25,18 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
   const [submittedApplication, setSubmittedApplication] = useState(
     applications.find((application) => application.status === 'SUBMITTED'),
   );
+  const [isOpenResultDelayModal, setIsOpenResultDelayModal] = useState(false);
+
+  useEffect(() => {
+    const { localStorage } = window;
+    if (!localStorage.getItem(IS_FIRST_VISIT)) {
+      setIsOpenResultDelayModal(true);
+    }
+
+    if (localStorage.getItem(IS_FIRST_VISIT) === null) {
+      window.localStorage.setItem(IS_FIRST_VISIT, 'false');
+    }
+  }, []);
 
   if (!submittedApplication || recruitingProgressStatus === 'AFTER-FIRST-SEMINAR') return null;
 
@@ -33,6 +47,14 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
     return (
       <Styled.StatusDetail>
         <ScreeningWait />
+        {isOpenResultDelayModal && (
+          <AlertModalDialog
+            heading="서류 결과는 4월 3일 오전 10시에 발표됩니다"
+            paragraph="이번 12기 모집에 예상보다 많은 분들이 지원해주셔서 기간 내 서류 검토가 어려워 하루 늦어짐을 공지드립니다. 일정 변동된 점 양해 부탁드립니다."
+            handleApprovalButton={() => setIsOpenResultDelayModal(false)}
+            setIsOpenModal={setIsOpenResultDelayModal}
+          />
+        )}
       </Styled.StatusDetail>
     );
   }


### PR DESCRIPTION
## 변경사항

- 서류 발표 지연에 대한 메시지를 1회성으로 노출시키는 기능을 추가합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
