### PR TITLE
최종 발표 이후 면접 거절자들에게 표시 되는 조건 추가, 컴포넌트명 변경

### DIFF
--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -2,7 +2,7 @@ import {
   ScreeningWait,
   ScreeningPass,
   ScreeningFail,
-  ScreeningReject,
+  InterviewReject,
   InterviewAccept,
   InterviewPass,
   InterviewFail,
@@ -82,7 +82,7 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
             }
 
             if (submittedApplication.confirmationStatus === 'INTERVIEW_CONFIRM_REJECTED') {
-              return <ScreeningReject application={submittedApplication} />;
+              return <InterviewReject application={submittedApplication} />;
             }
           }
 
@@ -112,7 +112,7 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
             submittedApplication.result.status === 'SCREENING_PASSED' &&
             submittedApplication.confirmationStatus === 'INTERVIEW_CONFIRM_REJECTED'
           ) {
-            return <ScreeningReject application={submittedApplication} />;
+            return <InterviewReject application={submittedApplication} />;
           }
 
           if (submittedApplication.result.status === 'INTERVIEW_PASSED') {

--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -104,6 +104,17 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
     return (
       <Styled.StatusDetail>
         {(() => {
+          if (submittedApplication.result.status === 'SCREENING_FAILED') {
+            return <ScreeningFail application={submittedApplication} />;
+          }
+
+          if (
+            submittedApplication.result.status === 'SCREENING_PASSED' &&
+            submittedApplication.confirmationStatus === 'INTERVIEW_CONFIRM_REJECTED'
+          ) {
+            return <ScreeningReject application={submittedApplication} />;
+          }
+
           if (submittedApplication.result.status === 'INTERVIEW_PASSED') {
             if (submittedApplication.confirmationStatus === 'FINAL_CONFIRM_WAITING') {
               return (
@@ -125,10 +136,6 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
 
           if (submittedApplication.result.status === 'INTERVIEW_FAILED') {
             return <InterviewFail application={submittedApplication} />;
-          }
-
-          if (submittedApplication.result.status === 'SCREENING_FAILED') {
-            return <ScreeningFail application={submittedApplication} />;
           }
 
           return (

--- a/src/components/applyStatus/InterviewReject/InterviewReject.component.tsx
+++ b/src/components/applyStatus/InterviewReject/InterviewReject.component.tsx
@@ -1,11 +1,11 @@
 import { Application } from '@/types/dto';
 import { ProcessFail } from '@/components';
 
-interface ScreeningRejectProps {
+interface InterviewRejectProps {
   application: Application;
 }
 
-const ScreeningReject = ({ application }: ScreeningRejectProps) => {
+const InterviewReject = ({ application }: InterviewRejectProps) => {
   const { applicant } = application;
   return (
     <ProcessFail
@@ -15,4 +15,4 @@ const ScreeningReject = ({ application }: ScreeningRejectProps) => {
   );
 };
 
-export default ScreeningReject;
+export default InterviewReject;

--- a/src/components/applyStatus/index.ts
+++ b/src/components/applyStatus/index.ts
@@ -5,7 +5,7 @@ export { default as ScreeningWait } from './ScreeningWait/ScreeningWait.componen
 export { default as ScreeningPass } from './ScreeningPass/ScreeningPass.component';
 export { default as ProcessFail } from './ProcessFail/ProcessFail.component';
 export { default as ScreeningFail } from './ScreeningFail/ScreeningFail.component';
-export { default as ScreeningReject } from './ScreeningReject/ScreeningReject.component';
+export { default as InterviewReject } from './InterviewReject/InterviewReject.component';
 export { default as InterviewAccept } from './InterviewAccept/InterviewAccept.component';
 export { default as InterviewPass } from './InterviewPass/InterviewPass.component';
 export { default as InterviewFail } from './InterviewFail/InterviewFail.component';


### PR DESCRIPTION
## 변경사항

- 기존에 서류 합격 이후 면접 참여 거절 한 유저들에 대해 최종 발표 시간 이후에도 동일하게 면접 거절 메시지가 노출되게끔 조건식을 추가해주었습니다.
- 인터뷰 거절일때 노출되는 컴포넌트의 이름이 ScreeningReject로 서류거절로 되어있어 이것을 InterviewReject로 인터뷰 거절이라는 적절한 네이밍으로 변경해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
