### PR TITLE
줄바꿈 이슈 및 최종 합류 안내 메시지 수정

### DIFF
--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -16,8 +16,8 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
         </Styled.NoticeMessage>
         <Styled.NoticeDetail>
           안녕하세요 {applicant.name}님! Mash-Up 12기 {TEAM_NICK_NAME[team.name]}과 함께하게 되어
-          너무 기뻐요! 12기 Rookie를 맞이할 준비하고 있을게요! 함께하게 되어 너무 기뻐요!! OT때
-          만나요!!
+          너무 기뻐요! 15일 금요일 오후 중으로 Mash-Up 12기 단톡방에 초대해드리겠습니다. 앞으로 잘
+          부탁드립니다!
         </Styled.NoticeDetail>
       </Styled.NoticeSection>
       <Styled.OtDetailSection>

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.styled.ts
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.styled.ts
@@ -124,6 +124,7 @@ export const OtDetailContent = styled.time`
 export const SatisfactionSurveyLink = styled.a`
   ${({ theme }) => css`
     color: ${theme.colors.white};
+    word-break: break-all;
   `}
 `;
 


### PR DESCRIPTION
## 변경사항

- work-break: keep-all속성 때문에 최종 합류 결정한 지원자에게 노출되는 설문 링크가 줄바꿈되지 않는 이슈를 word-break: break-all속성으로 변경하여 해결해주었습니다.
- 최종 합류 결정한 지원자에게 노출되는 메시지 워딩을 변경해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
