### PR TITLE
누락된 description meta태그 추가

### DIFF
--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -6,6 +6,8 @@ export const titleTemplate = 'Mash-up Recruit | ';
 
 export const defaultSEOConfig: DefaultSEOProps = {
   title: 'IT 연합 동아리',
+  description:
+    '매쉬업은 개발, 디자인에 관심과 열정이 있는 사람들이 모인 단체로 Product Design, Android, iOS, Backend(노드,스프링), Web 총 6개의 팀으로 구성되어 있습니다. 매쉬업에서는 전체모임의 세미나 및 네트워킹을 진행하고 있으며, 이를 통하여 개인의 전문역량과 협업능력을 증대시키고자 합니다.',
   openGraph: {
     type: 'website',
     url: 'https://recruit.mash-up.kr',


### PR DESCRIPTION
## 변경사항

- seoConfig에 og:description은 입력되어 있지만 description은 누락되어 있어 추가해주었습니다.
![image](https://user-images.githubusercontent.com/71176945/207852816-7b0a28ed-0571-4200-b805-541aefacd733.png)


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
