### PR TITLE
지원서 별로 각각 기수정보가 추가되어 내려오게끔 수정된 api에 대응

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,11 +26,7 @@ yarn-error.log*
 build-storybook.log*
 
 # local env files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
 
 # vercel
 .vercel

--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -40,10 +40,6 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
 
   if (!submittedApplication || recruitingProgressStatus === 'AFTER-FIRST-SEMINAR') return null;
 
-  if (submittedApplication.applicationId === 313) {
-    console.log(submittedApplication);
-  }
-
   if (
     recruitingProgressStatus === 'IN-RECRUITING' ||
     recruitingProgressStatus === 'END-RECRUITING'

--- a/src/components/applyStatus/StatusList/StatusList.component.tsx
+++ b/src/components/applyStatus/StatusList/StatusList.component.tsx
@@ -57,25 +57,29 @@ const StatusList = ({ applications, recruitingProgressStatus }: StatusListProps)
                 </Styled.NoSubmittedApplication>
               ) : (
                 <Styled.StatusList>
-                  {applications.map(({ applicant, team, applicationId, result }) => {
-                    return (
-                      <Styled.StatusListItem key={applicationId}>
-                        <Styled.StatusText>12기</Styled.StatusText>
-                        <Styled.StatusText>{unescape(applicant.name)}</Styled.StatusText>
-                        <Styled.StatusText>{TEAM_NICK_NAME[team.name]}</Styled.StatusText>
-                        <Styled.ApplicationStatus status={result.status}>
-                          {STATUS_WORDS[result.status]}
-                        </Styled.ApplicationStatus>
-                        <Styled.DetailLinkWrapper>
-                          <Styled.ApplicationDetailLink
-                            href={`${MY_PAGE_APPLICATION_DETAIL}/${applicationId}`}
-                          >
-                            상세보기
-                          </Styled.ApplicationDetailLink>
-                        </Styled.DetailLinkWrapper>
-                      </Styled.StatusListItem>
-                    );
-                  })}
+                  {applications.map(
+                    ({ applicant, team, applicationId, result, generationResponse }) => {
+                      return (
+                        <Styled.StatusListItem key={applicationId}>
+                          <Styled.StatusText>
+                            {generationResponse.generationNumber}기
+                          </Styled.StatusText>
+                          <Styled.StatusText>{unescape(applicant.name)}</Styled.StatusText>
+                          <Styled.StatusText>{TEAM_NICK_NAME[team.name]}</Styled.StatusText>
+                          <Styled.ApplicationStatus status={result.status}>
+                            {STATUS_WORDS[result.status]}
+                          </Styled.ApplicationStatus>
+                          <Styled.DetailLinkWrapper>
+                            <Styled.ApplicationDetailLink
+                              href={`${MY_PAGE_APPLICATION_DETAIL}/${applicationId}`}
+                            >
+                              상세보기
+                            </Styled.ApplicationDetailLink>
+                          </Styled.DetailLinkWrapper>
+                        </Styled.StatusListItem>
+                      );
+                    },
+                  )}
                 </Styled.StatusList>
               )}
             </>
@@ -88,37 +92,41 @@ const StatusList = ({ applications, recruitingProgressStatus }: StatusListProps)
                 </Styled.NoSubmittedApplication>
               ) : (
                 <Styled.StatusList>
-                  {applications.map(({ applicant, team, applicationId, result }) => {
-                    return (
-                      <Styled.StatusListItem key={applicationId}>
-                        <Styled.ListItemWrapper>
-                          <Styled.StatusListHeading>기수</Styled.StatusListHeading>
-                          <Styled.StatusText>12기</Styled.StatusText>
-                        </Styled.ListItemWrapper>
-                        <Styled.ListItemWrapper>
-                          <Styled.StatusListHeading>이름</Styled.StatusListHeading>
-                          <Styled.StatusText>{unescape(applicant.name)}</Styled.StatusText>
-                        </Styled.ListItemWrapper>
-                        <Styled.ListItemWrapper>
-                          <Styled.StatusListHeading>플랫폼</Styled.StatusListHeading>
-                          <Styled.StatusText>{TEAM_NICK_NAME[team.name]}</Styled.StatusText>
-                        </Styled.ListItemWrapper>
-                        <Styled.ListItemWrapper>
-                          <Styled.StatusListHeading>지원상태</Styled.StatusListHeading>
-                          <Styled.ApplicationStatus status={result.status}>
-                            {STATUS_WORDS[result.status]}
-                          </Styled.ApplicationStatus>
-                        </Styled.ListItemWrapper>
-                        <Styled.DetailLinkWrapper>
-                          <Styled.ApplicationDetailLink
-                            href={`${MY_PAGE_APPLICATION_DETAIL}/${applicationId}`}
-                          >
-                            지원서 상세보기
-                          </Styled.ApplicationDetailLink>
-                        </Styled.DetailLinkWrapper>
-                      </Styled.StatusListItem>
-                    );
-                  })}
+                  {applications.map(
+                    ({ applicant, team, applicationId, result, generationResponse }) => {
+                      return (
+                        <Styled.StatusListItem key={applicationId}>
+                          <Styled.ListItemWrapper>
+                            <Styled.StatusListHeading>기수</Styled.StatusListHeading>
+                            <Styled.StatusText>
+                              {generationResponse.generationNumber}기
+                            </Styled.StatusText>
+                          </Styled.ListItemWrapper>
+                          <Styled.ListItemWrapper>
+                            <Styled.StatusListHeading>이름</Styled.StatusListHeading>
+                            <Styled.StatusText>{unescape(applicant.name)}</Styled.StatusText>
+                          </Styled.ListItemWrapper>
+                          <Styled.ListItemWrapper>
+                            <Styled.StatusListHeading>플랫폼</Styled.StatusListHeading>
+                            <Styled.StatusText>{TEAM_NICK_NAME[team.name]}</Styled.StatusText>
+                          </Styled.ListItemWrapper>
+                          <Styled.ListItemWrapper>
+                            <Styled.StatusListHeading>지원상태</Styled.StatusListHeading>
+                            <Styled.ApplicationStatus status={result.status}>
+                              {STATUS_WORDS[result.status]}
+                            </Styled.ApplicationStatus>
+                          </Styled.ListItemWrapper>
+                          <Styled.DetailLinkWrapper>
+                            <Styled.ApplicationDetailLink
+                              href={`${MY_PAGE_APPLICATION_DETAIL}/${applicationId}`}
+                            >
+                              지원서 상세보기
+                            </Styled.ApplicationDetailLink>
+                          </Styled.DetailLinkWrapper>
+                        </Styled.StatusListItem>
+                      );
+                    },
+                  )}
                 </Styled.StatusList>
               )}
             </>

--- a/src/types/dto/application.ts
+++ b/src/types/dto/application.ts
@@ -44,6 +44,11 @@ type ConfirmationStatus =
 
 export type ApplicationStatus = 'CREATED' | 'SUBMITTED' | 'WRITING';
 
+interface Generation {
+  generationId: number;
+  generationNumber: number;
+}
+
 export interface Application {
   answers: Answer[];
   applicant: Applicant;
@@ -55,6 +60,7 @@ export interface Application {
   status: ApplicationStatus;
   submittedAt: string;
   team: Team;
+  generationResponse: Generation;
 }
 
 interface UpdateApplication {


### PR DESCRIPTION
## 변경사항

- 기존 지원현황에 지원서들이 무조건 12기로 노출되던것을 api에서 지원서별 기수정보를 내려주게끔 변경되어 이를 대응해줍니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
