### PR TITLE
applyForm 페이지 로직 리팩토링 (코드 분리, 수정)

### DIFF
--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -1,56 +1,29 @@
 import { applicationApiService } from '@/api/services';
 import {
-  AlertModalDialog,
-  ConfirmModalDialog,
   LabeledCheckbox,
-  LabeledInput,
-  LabeledTextArea,
   LoadingModal,
+  PersonalInformation,
+  QuestionAndAnswerList,
+  BlockingConfirmModalDialog,
+  TempSaveModalDialog,
+  SubmitModalDialog,
 } from '@/components';
 import { HOME_PAGE, MY_PAGE_APPLY_STATUS, PATH_NAME } from '@/constants';
-import { usePreventPageChange } from '@/hooks';
-import { ValueOf } from '@/types';
 import { Application } from '@/types/dto';
-import { isValidDate } from '@/utils/validDateString';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
+import { MouseEventHandler, MutableRefObject, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import {
-  ChangeEventHandler,
-  Dispatch,
-  MouseEventHandler,
-  MutableRefObject,
-  SetStateAction,
-  useRef,
-  useState,
-} from 'react';
-import { Controller, FieldValues, useForm } from 'react-hook-form';
-import unescape from 'lodash-es/unescape';
+  ApplyFormValues,
+  APPLY_FORM_KEYS,
+} from '../PersonalInformation/PersonalInformation.component';
 import * as Styled from './ApplyForm.styled';
 
 interface ApplyFormProps {
   application: Application;
   isSubmitted: boolean;
 }
-
-interface ApplyFormValues extends FieldValues {
-  userName: string;
-  email: string;
-  phone: string;
-  birthdate: string;
-  residence: string;
-  department: string;
-  isAgreePersonalInfo: boolean;
-}
-
-const APPLY_FORM_KEYS = {
-  userName: 'userName',
-  email: 'email',
-  phone: 'phone',
-  birthdate: 'birthdate',
-  residence: 'residence',
-  department: 'department',
-  isAgreePersonalInfo: 'isAgreePersonalInfo',
-} as const;
 
 const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
   const session = useSession();
@@ -60,25 +33,12 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
   const submitButtonRef = useRef() as MutableRefObject<HTMLButtonElement>;
 
   const [isRequesting, setIsRequesting] = useState(false);
-
   const [isTempSaved, setIsTempSaved] = useState(false);
 
   const [isOpenTempSaveSuccessAlertModal, setIsOpenTempSaveSuccessAlertModal] = useState(false);
   const [isOpenTempSaveFailedAlertModal, setIsOpenTempSaveFailedAlertModal] = useState(false);
   const [isOpenConfirmSubmittedModal, setIsOpenConfirmSubmittedModal] = useState(false);
-  const [isOpenFailedSubmittedModal, setIsOpenFailedSubmittedModal] = useState(false);
-  const [isOpenBlockingConfirmModal, setIsOpenBlockingConfirmModal] = useState(false);
   const [isOpenSuccessSubmittedModal, setIsOpenSuccessSubmittedModal] = useState(false);
-
-  const handleCloseBlockingConfirmModal = () => {
-    setIsOpenBlockingConfirmModal(false);
-  };
-
-  const handleCloseTempSaveAlertModal = (
-    setIsOpenAlertModal: Dispatch<SetStateAction<boolean>>,
-  ) => {
-    setIsOpenAlertModal(false);
-  };
 
   const { questions, applicationId, answers, applicant } = application;
 
@@ -93,65 +53,15 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
     return { question, answer: questionMatchAnswer };
   });
 
+  const applyForm = useForm<ApplyFormValues>();
   const {
     register,
     handleSubmit,
     watch,
-    setValue,
     trigger,
     setFocus,
-    control,
-    formState: { errors, isDirty },
-  } = useForm<ApplyFormValues>();
-
-  const { handleMoveAfterBlocking } = usePreventPageChange(setIsOpenBlockingConfirmModal, [
-    isOpenBlockingConfirmModal,
-    isOpenSuccessSubmittedModal,
-    !isDirty,
-    isTempSaved,
-  ]);
-
-  const handleReplacePhoneNumber: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
-    const onlyNumberReg = /[^0-9]/g;
-
-    if (onlyNumberReg.exec(currentTarget.value)) {
-      setValue(APPLY_FORM_KEYS.phone, currentTarget.value.replace(onlyNumberReg, ''));
-    }
-
-    const restNumber = currentTarget.value.slice(3);
-    const phoneNumberArr = [
-      currentTarget.value.slice(0, 3),
-      restNumber.slice(0, 4),
-      restNumber.slice(4),
-    ];
-
-    const replacedPhoneNumber = phoneNumberArr.filter((isEmptyStr) => isEmptyStr).join('-');
-
-    setValue(APPLY_FORM_KEYS.phone, replacedPhoneNumber);
-  };
-
-  const handleReplaceLocalDate: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
-    const onlyNumberReg = /[^0-9]/g;
-
-    if (onlyNumberReg.exec(currentTarget.value)) {
-      setValue(APPLY_FORM_KEYS.birthdate, currentTarget.value.replace(onlyNumberReg, ''));
-    }
-
-    const restNumber = currentTarget.value.slice(4);
-    const localDateArr = [
-      currentTarget.value.slice(0, 4),
-      restNumber.slice(0, 2),
-      restNumber.slice(2),
-    ];
-
-    const replacedLocalDate = localDateArr.filter((isEmptyStr) => isEmptyStr).join('-');
-
-    setValue(APPLY_FORM_KEYS.birthdate, replacedLocalDate);
-  };
-
-  const handleValidateForm = (formKey: ValueOf<ApplyFormValues>) => {
-    trigger(formKey);
-  };
+    formState: { isDirty },
+  } = applyForm;
 
   const handleTempSaveApplication: MouseEventHandler<HTMLButtonElement> = async () => {
     if (session.status === 'unauthenticated') return;
@@ -212,312 +122,22 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
     setIsOpenConfirmSubmittedModal(true);
   };
 
-  const handleSubmitApplication = async () => {
-    if (session.status === 'unauthenticated') return;
-
-    const { userName, phone, isAgreePersonalInfo, birthdate, department, residence } = watch();
-
-    const applicationSubmitRequest = {
-      applicantName: userName,
-      phoneNumber: phone,
-      privacyPolicyAgreed: isAgreePersonalInfo,
-      birthdate,
-      department,
-      residence,
-      answers: questionsAndAnswers.map(({ question, answer }) => {
-        const uniqueQuestionId = `question-${question.questionId}`;
-
-        return {
-          answerId: answer.answerId,
-          questionId: question.questionId,
-          content: watch(uniqueQuestionId),
-        };
-      }),
-    };
-
-    setIsRequesting(true);
-
-    try {
-      await applicationApiService.submitApplication({
-        accessToken: session.data?.accessToken,
-        applicationId,
-        applicationSubmitRequest,
-      });
-
-      setIsRequesting(false);
-      setIsOpenConfirmSubmittedModal(false);
-      setIsOpenSuccessSubmittedModal(true);
-    } catch (error) {
-      setIsRequesting(false);
-      setIsOpenConfirmSubmittedModal(false);
-      setIsOpenFailedSubmittedModal(true);
-    }
-  };
-
   const isDetailPageAndSubmitted =
     isSubmitted && router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL;
 
   return (
     <>
       <form onSubmit={handleSubmit(handleOpenSubmitModal)}>
-        <Styled.PersonalInformationSection>
-          <Styled.SectionHeading>개인 정보</Styled.SectionHeading>
-
-          <Styled.PersonalInformationWrapper>
-            <Controller
-              name={APPLY_FORM_KEYS.userName}
-              control={control}
-              rules={{
-                required: '이름은 필수로 입력해야 해요!',
-                maxLength: 24,
-              }}
-              defaultValue={unescape(applicant.name)}
-              render={({ field }) => (
-                <LabeledInput
-                  {...field}
-                  onChange={({ target }) => {
-                    if (target.value.length > 24) return;
-                    field.onChange(target.value);
-                  }}
-                  isError={!!errors.userName}
-                  errorMessage={errors.userName?.message}
-                  id={APPLY_FORM_KEYS.userName}
-                  placeholder="내용을 입력해주세요"
-                  label="이름"
-                  required
-                  disabled={isDetailPageAndSubmitted}
-                  $size="md"
-                  onBlur={() => {
-                    handleValidateForm(APPLY_FORM_KEYS.userName);
-                  }}
-                />
-              )}
-            />
-          </Styled.PersonalInformationWrapper>
-
-          <Styled.PersonalInformationWrapper>
-            <LabeledInput
-              {...register(APPLY_FORM_KEYS.phone, {
-                required: '전화번호는 필수로 입력해야 해요!',
-                pattern: {
-                  value: /^010-\d{3,4}-\d{4}$/,
-                  message: '전화번호 형식이 올바르지 않습니다.',
-                },
-                value: applicant.phoneNumber,
-              })}
-              maxLength={13}
-              type="tel"
-              onChange={handleReplacePhoneNumber}
-              id={APPLY_FORM_KEYS.phone}
-              placeholder="전화번호를 입력해주세요"
-              label="전화번호"
-              required
-              disabled={isDetailPageAndSubmitted}
-              isError={!!errors.phone}
-              errorMessage={errors.phone?.message}
-              $size="md"
-              onBlur={() => {
-                handleValidateForm(APPLY_FORM_KEYS.phone);
-              }}
-            />
-          </Styled.PersonalInformationWrapper>
-
-          <Styled.PersonalInformationWrapper>
-            <LabeledInput
-              id={APPLY_FORM_KEYS.email}
-              value={unescape(applicant.email)}
-              disabled
-              label="이메일"
-              $size="md"
-              required
-              type="email"
-            />
-          </Styled.PersonalInformationWrapper>
-
-          <Styled.PersonalInformationWrapper>
-            <LabeledInput
-              {...register(APPLY_FORM_KEYS.birthdate, {
-                required: '생년월일은 필수로 입력해야 해요!',
-                value: applicant.birthdate,
-                validate: (value) => isValidDate(value) || '생년월일 형식이 올바르지 않습니다.',
-              })}
-              maxLength={10}
-              type="text"
-              onChange={handleReplaceLocalDate}
-              id={APPLY_FORM_KEYS.birthdate}
-              placeholder="생년월일을 입력해주세요 ex) 2000-01-15"
-              label="생년월일"
-              required
-              disabled={isDetailPageAndSubmitted}
-              isError={!!errors.birthdate}
-              errorMessage={errors.birthdate?.message}
-              $size="md"
-              onBlur={() => {
-                handleValidateForm(APPLY_FORM_KEYS.birthdate);
-              }}
-            />
-          </Styled.PersonalInformationWrapper>
-
-          <Styled.PersonalInformationWrapper>
-            <Controller
-              name={APPLY_FORM_KEYS.residence}
-              control={control}
-              rules={{
-                required: '거주지역은 필수로 입력해야 해요!',
-                maxLength: 30,
-              }}
-              defaultValue={unescape(applicant.residence)}
-              render={({ field }) => (
-                <LabeledInput
-                  {...field}
-                  onChange={({ target }) => {
-                    if (target.value.length > 30) return;
-                    field.onChange(target.value);
-                  }}
-                  isError={!!errors.residence}
-                  errorMessage={errors.residence?.message}
-                  id={APPLY_FORM_KEYS.residence}
-                  placeholder="거주지역을 입력해주세요 ex) 서울시 강남구"
-                  label="거주지역"
-                  required
-                  disabled={isDetailPageAndSubmitted}
-                  $size="md"
-                  onBlur={() => {
-                    handleValidateForm(APPLY_FORM_KEYS.residence);
-                  }}
-                />
-              )}
-            />
-          </Styled.PersonalInformationWrapper>
-
-          <Styled.PersonalInformationWrapper>
-            <Controller
-              name={APPLY_FORM_KEYS.department}
-              control={control}
-              rules={{
-                required: '소속은 필수로 입력해야 해요!',
-                maxLength: 50,
-              }}
-              defaultValue={unescape(applicant.department)}
-              render={({ field }) => (
-                <LabeledInput
-                  {...field}
-                  onChange={({ target }) => {
-                    if (target.value.length > 50) return;
-                    field.onChange(target.value);
-                  }}
-                  isError={!!errors.department}
-                  errorMessage={errors.department?.message}
-                  id={APPLY_FORM_KEYS.department}
-                  placeholder="소속을 입력해주세요 ex) 회사, 학교, 취준생..."
-                  label="소속"
-                  required
-                  disabled={isDetailPageAndSubmitted}
-                  $size="md"
-                  onBlur={() => {
-                    handleValidateForm(APPLY_FORM_KEYS.department);
-                  }}
-                />
-              )}
-            />
-          </Styled.PersonalInformationWrapper>
-        </Styled.PersonalInformationSection>
-        <Styled.QuestionListSection>
-          <Styled.SectionHeading>질문 목록</Styled.SectionHeading>
-          {questionsAndAnswers?.map(({ question, answer }, index) => {
-            const uniqueQuestionId = `question-${question.questionId}`;
-            return (
-              <Styled.QuestionWrapper key={uniqueQuestionId}>
-                {question.questionType === 'MULTI_LINE_TEXT' ? (
-                  <Controller
-                    name={uniqueQuestionId}
-                    control={control}
-                    rules={{
-                      required: {
-                        value: question.required,
-                        message: '필수로 입력해야하는 항목이에요!',
-                      },
-                      maxLength: {
-                        value: question.maxContentLength || 10000,
-                        message: '최대 글자수를 초과하였습니다.',
-                      },
-                    }}
-                    defaultValue={unescape(answer?.content)}
-                    render={({ field }) => (
-                      <LabeledTextArea
-                        {...field}
-                        onChange={({ target }) => {
-                          const { maxContentLength } = question;
-                          if (!maxContentLength && target.value.length > 10000) return;
-
-                          if (maxContentLength && maxContentLength < target.value.length) return;
-
-                          field.onChange(target.value);
-                        }}
-                        label={`${index + 1}. ${question.content}`}
-                        placeholder="내용을 입력해주세요."
-                        required={question.required}
-                        disabled={isDetailPageAndSubmitted}
-                        id={uniqueQuestionId}
-                        isError={!!errors[uniqueQuestionId]}
-                        errorMessage={errors[uniqueQuestionId]?.message}
-                        onBlur={() => {
-                          handleValidateForm(uniqueQuestionId);
-                        }}
-                        currentLength={watch(uniqueQuestionId)?.length}
-                        maxContentLength={question.maxContentLength}
-                        description={question.description}
-                      />
-                    )}
-                  />
-                ) : (
-                  <Controller
-                    name={uniqueQuestionId}
-                    control={control}
-                    rules={{
-                      required: {
-                        value: question.required,
-                        message: '필수로 입력해야하는 항목이에요!',
-                      },
-                      maxLength: {
-                        value: question.maxContentLength || 10000,
-                        message: '최대 글자수를 초과하였습니다.',
-                      },
-                    }}
-                    defaultValue={unescape(answer?.content)}
-                    render={({ field }) => (
-                      <LabeledInput
-                        {...field}
-                        onChange={({ target }) => {
-                          const { maxContentLength } = question;
-                          if (!maxContentLength && target.value.length > 10000) return;
-
-                          if (maxContentLength && maxContentLength < target.value.length) return;
-
-                          field.onChange(target.value);
-                        }}
-                        id={uniqueQuestionId}
-                        label={`${index + 1}. ${question.content}`}
-                        required={question.required}
-                        disabled={isDetailPageAndSubmitted}
-                        $size="md"
-                        placeholder="내용을 입력해주세요."
-                        isError={!!errors[uniqueQuestionId]}
-                        errorMessage={errors[uniqueQuestionId]?.message}
-                        onBlur={() => {
-                          handleValidateForm(uniqueQuestionId);
-                        }}
-                        currentLength={watch(uniqueQuestionId)?.length}
-                        maxContentLength={question.maxContentLength}
-                        description={question.description}
-                      />
-                    )}
-                  />
-                )}
-              </Styled.QuestionWrapper>
-            );
-          })}
-        </Styled.QuestionListSection>
+        <PersonalInformation
+          applicant={applicant}
+          applyForm={applyForm}
+          isDetailPageAndSubmitted={isDetailPageAndSubmitted}
+        />
+        <QuestionAndAnswerList
+          applyForm={applyForm}
+          questionsAndAnswers={questionsAndAnswers}
+          isDetailPageAndSubmitted={isDetailPageAndSubmitted}
+        />
         <LabeledCheckbox
           {...register(APPLY_FORM_KEYS.isAgreePersonalInfo)}
           checked={isDetailPageAndSubmitted ? true : watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
@@ -525,7 +145,7 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
           disabled={isDetailPageAndSubmitted}
         >
           <a
-            href="https://snow-chestnut-45b.notion.site/Mash-Up-Recruit-62a5f6dabcb34e61ba8f26c4fb3a21f0"
+            href="https://snow-chestnut-45b.notion.site/Mash-Up-Recruit-d4d1eccd3e504bcba575d6e5a95cf1b1"
             target="_blank"
             rel="noreferrer"
           >
@@ -579,87 +199,30 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
           </Styled.BackToListLink>
         </Styled.ControlSection>
       </form>
-      {isOpenTempSaveSuccessAlertModal && (
-        <AlertModalDialog
-          beforeRef={tempSaveButtonRef}
-          heading="임시 저장 완료!"
-          paragraph="기간 내에 지원서는 꼭! 잊지말고 제출해주세요!"
-          handleApprovalButton={() => {
-            router.push(MY_PAGE_APPLY_STATUS);
-            handleCloseTempSaveAlertModal(setIsOpenTempSaveSuccessAlertModal);
-          }}
-          setIsOpenModal={setIsOpenTempSaveSuccessAlertModal}
-          deemClose={false}
-          escClose={false}
-          enterClose={false}
-        />
-      )}
-      {isOpenTempSaveFailedAlertModal && (
-        <AlertModalDialog
-          beforeRef={tempSaveButtonRef}
-          heading="임시 저장 실패"
-          paragraph="다시 시도해주세요! 계속 임시 저장이 실패된다면 매쉬업 채널톡으로 문의해주세요!"
-          handleApprovalButton={() =>
-            handleCloseTempSaveAlertModal(setIsOpenTempSaveFailedAlertModal)
-          }
-          setIsOpenModal={setIsOpenTempSaveFailedAlertModal}
-          deemClose={false}
-          escClose={false}
-          isError
-        />
-      )}
-      {isOpenConfirmSubmittedModal && (
-        <ConfirmModalDialog
-          heading="지원서를 제출하시겠어요?"
-          paragraph="제출하시면 더 이상 지원서를 수정하거나 삭제할 수 없으며, 중복 지원은 불가한 점 참고 부탁드립니다. 지원 관련 문의는 채널톡으로 해주시면 됩니다."
-          approvalButtonMessage="제출하기"
-          cancelButtonMessage="취소"
-          handleApprovalButton={handleSubmitApplication}
-          handleCancelButton={() => setIsOpenConfirmSubmittedModal(false)}
-          setIsOpenModal={setIsOpenConfirmSubmittedModal}
-          beforeRef={submitButtonRef}
-        />
-      )}
-      {isOpenSuccessSubmittedModal && (
-        <ConfirmModalDialog
-          heading="지원서 제출 완료!"
-          paragraph="귀한 시간내어 매쉬업 12기에 지원해주셔서 진심으로 감사드립니다! 4월 3일(일) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
-          approvalButtonMessage="내 지원서 확인하기"
-          cancelButtonMessage="홈으로"
-          setIsOpenModal={setIsOpenSuccessSubmittedModal}
-          handleCancelButton={() => router.push(HOME_PAGE)}
-          handleApprovalButton={() => {
-            router.push(MY_PAGE_APPLY_STATUS);
-            setIsTempSaved(true);
-            setIsOpenSuccessSubmittedModal(false);
-          }}
-          escClose={false}
-          deemClose={false}
-        />
-      )}
-      {isOpenFailedSubmittedModal && (
-        <AlertModalDialog
-          heading="지원서 제출 실패"
-          paragraph="다시 시도해주세요! 계속 제출하기가 실패된다면 매쉬업 채널톡으로 문의해주세요!"
-          beforeRef={submitButtonRef}
-          setIsOpenModal={setIsOpenFailedSubmittedModal}
-          handleApprovalButton={() => setIsOpenFailedSubmittedModal(false)}
-          escClose={false}
-          deemClose={false}
-          isError
-        />
-      )}
-      {isOpenBlockingConfirmModal && (
-        <ConfirmModalDialog
-          approvalButtonMessage="나가기"
-          cancelButtonMessage="머물기"
-          handleApprovalButton={handleMoveAfterBlocking}
-          handleCancelButton={handleCloseBlockingConfirmModal}
-          heading="지금..나가시게요..?"
-          paragraph="저장 안된 내용은..날아갈 수 있다능.."
-          setIsOpenModal={setIsOpenBlockingConfirmModal}
-        />
-      )}
+      <BlockingConfirmModalDialog
+        isDirty={isDirty}
+        isOpenSuccessSubmittedModal={isOpenSuccessSubmittedModal}
+        isTempSaved={isTempSaved}
+      />
+      <TempSaveModalDialog
+        isOpenTempSaveFailedAlertModal={isOpenTempSaveFailedAlertModal}
+        isOpenTempSaveSuccessAlertModal={isOpenTempSaveSuccessAlertModal}
+        setIsOpenTempSaveFailedAlertModal={setIsOpenTempSaveFailedAlertModal}
+        setIsOpenTempSaveSuccessAlertModal={setIsOpenTempSaveSuccessAlertModal}
+        tempSaveButtonRef={tempSaveButtonRef}
+      />
+      <SubmitModalDialog
+        applicationId={applicationId}
+        applyForm={applyForm}
+        isOpenConfirmSubmittedModal={isOpenConfirmSubmittedModal}
+        isOpenSuccessSubmittedModal={isOpenSuccessSubmittedModal}
+        setIsOpenConfirmSubmittedModal={setIsOpenConfirmSubmittedModal}
+        setIsOpenSuccessSubmittedModal={setIsOpenSuccessSubmittedModal}
+        setIsRequesting={setIsRequesting}
+        setIsTempSaved={setIsTempSaved}
+        questionsAndAnswers={questionsAndAnswers}
+        submitButtonRef={submitButtonRef}
+      />
       {isRequesting && <LoadingModal setIsOpenModal={setIsRequesting} />}
     </>
   );

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -7,8 +7,10 @@ import {
   BlockingConfirmModalDialog,
   TempSaveModalDialog,
   SubmitModalDialog,
+  BackToListLink,
+  SubmittedButton,
 } from '@/components';
-import { HOME_PAGE, MY_PAGE_APPLY_STATUS, PATH_NAME } from '@/constants';
+import { PATH_NAME } from '@/constants';
 import { Application } from '@/types/dto';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
@@ -122,8 +124,8 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
     setIsOpenConfirmSubmittedModal(true);
   };
 
-  const isDetailPageAndSubmitted =
-    isSubmitted && router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL;
+  const isCurrentlyOnDetailPage = router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL;
+  const isDetailPageAndSubmitted = isSubmitted && isCurrentlyOnDetailPage;
 
   return (
     <>
@@ -155,18 +157,10 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
         </LabeledCheckbox>
         <Styled.ControlSection>
           {isSubmitted ? (
-            router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL &&
-            application.status === 'SUBMITTED' ? (
-              <Styled.SubmittedCompletedButton type="button" disabled>
-                제출 완료된 지원서 입니다
-              </Styled.SubmittedCompletedButton>
-            ) : (
-              isSubmitted && (
-                <Styled.AlreadySubmittedButton type="button" disabled>
-                  이미 제출한 지원서가 있습니다
-                </Styled.AlreadySubmittedButton>
-              )
-            )
+            <SubmittedButton
+              application={application}
+              isCurrentlyOnDetailPage={isCurrentlyOnDetailPage}
+            />
           ) : (
             <>
               <Styled.TempSaveButton
@@ -185,18 +179,7 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
               </Styled.SubmitButton>
             </>
           )}
-          <Styled.BackToListLink
-            href={
-              router.pathname === PATH_NAME.APPLY_PAGE
-                ? `/recruit/${application.team.name.toLowerCase()}`
-                : router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL
-                ? MY_PAGE_APPLY_STATUS
-                : HOME_PAGE
-            }
-          >
-            <Styled.ChevronLeft />
-            <span>목록으로 돌아가기</span>
-          </Styled.BackToListLink>
+          <BackToListLink application={application} />
         </Styled.ControlSection>
       </form>
       <BlockingConfirmModalDialog

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -1,6 +1,5 @@
 import { applicationApiService } from '@/api/services';
 import {
-  LabeledCheckbox,
   LoadingModal,
   PersonalInformation,
   QuestionAndAnswerList,
@@ -9,6 +8,7 @@ import {
   SubmitModalDialog,
   BackToListLink,
   SubmittedButton,
+  PersonalInfoAgree,
 } from '@/components';
 import { PATH_NAME } from '@/constants';
 import { Application } from '@/types/dto';
@@ -57,7 +57,6 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
 
   const applyForm = useForm<ApplyFormValues>();
   const {
-    register,
     handleSubmit,
     watch,
     trigger,
@@ -140,21 +139,10 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
           questionsAndAnswers={questionsAndAnswers}
           isDetailPageAndSubmitted={isDetailPageAndSubmitted}
         />
-        <LabeledCheckbox
-          {...register(APPLY_FORM_KEYS.isAgreePersonalInfo)}
-          checked={isDetailPageAndSubmitted ? true : watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
-          id={APPLY_FORM_KEYS.isAgreePersonalInfo}
-          disabled={isDetailPageAndSubmitted}
-        >
-          <a
-            href="https://snow-chestnut-45b.notion.site/Mash-Up-Recruit-d4d1eccd3e504bcba575d6e5a95cf1b1"
-            target="_blank"
-            rel="noreferrer"
-          >
-            개인정보 수집 및 이용
-          </a>
-          에 동의합니다.
-        </LabeledCheckbox>
+        <PersonalInfoAgree
+          applyForm={applyForm}
+          isDetailPageAndSubmitted={isDetailPageAndSubmitted}
+        />
         <Styled.ControlSection>
           {isSubmitted ? (
             <SubmittedButton

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -1,7 +1,5 @@
-import LinkTo from '@/components/common/LinkTo/LinkTo.component';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import ChevronRight7 from '@/assets/svg/chevron-right-7.svg';
 
 export const ControlSection = styled.div`
   ${({ theme }) => css`
@@ -55,34 +53,4 @@ export const SubmittedCompletedButton = styled.button`
     width: 100%;
     text-align: center;
   `}
-`;
-
-export const BackToListLink = styled(LinkTo)`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.medium16};
-    display: inline-block;
-    margin-top: 3.2rem;
-    padding: 0.8rem 1.2rem 0.6rem 0.2rem;
-    border-radius: 0.8rem;
-
-    & > span {
-      vertical-align: middle;
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        background: ${theme.colors.gray10};
-      }
-    }
-
-    &:active {
-      background: ${theme.colors.gray10};
-    }
-  `}
-`;
-
-export const ChevronLeft = styled(ChevronRight7)`
-  margin-right: 1.1rem;
-  margin-left: 1rem;
-  transform: rotate(180deg);
 `;

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -11,28 +11,3 @@ export const ControlSection = styled.div`
     }
   `}
 `;
-
-export const TempSaveButton = styled.button`
-  ${({ theme }) => css`
-    ${theme.button.type.primaryLine}
-    width: 20rem;
-    margin-right: 1.6rem;
-
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      width: 100%;
-      margin-right: 0;
-      margin-bottom: 1.6rem;
-    }
-  `}
-`;
-
-export const SubmitButton = styled.button`
-  ${({ theme }) => css`
-    ${theme.button.type.primary}
-    width: 20rem;
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      width: 100%;
-      margin-right: 0;
-    }
-  `}
-`;

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -3,39 +3,6 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import ChevronRight7 from '@/assets/svg/chevron-right-7.svg';
 
-export const PersonalInformationSection = styled.section`
-  margin-top: 6rem;
-`;
-
-export const SectionHeading = styled.h4`
-  ${({ theme }) => css`
-    ${theme.fonts.kr.bold24};
-    margin-bottom: 2.4rem;
-    color: ${theme.colors.gray80};
-    @media (max-width: ${theme.breakPoint.media.mobile}) {
-      ${theme.fonts.kr.bold22}
-    }
-  `}
-`;
-
-export const PersonalInformationWrapper = styled.div`
-  width: 100%;
-  max-width: 53.2rem;
-  margin-bottom: 3.6rem;
-
-  &:last-of-type {
-    margin-bottom: 0;
-  }
-`;
-
-export const QuestionListSection = styled.section`
-  margin-top: 6rem;
-`;
-
-export const QuestionWrapper = styled.div`
-  margin-bottom: 3.6rem;
-`;
-
 export const ControlSection = styled.div`
   ${({ theme }) => css`
     width: 41.6rem;

--- a/src/components/apply/ApplyForm/ApplyForm.styled.ts
+++ b/src/components/apply/ApplyForm/ApplyForm.styled.ts
@@ -36,21 +36,3 @@ export const SubmitButton = styled.button`
     }
   `}
 `;
-
-export const AlreadySubmittedButton = styled.button`
-  ${({ theme }) => css`
-    ${theme.button.type.primary}
-    display: inline-block;
-    width: 100%;
-    text-align: center;
-  `}
-`;
-
-export const SubmittedCompletedButton = styled.button`
-  ${({ theme }) => css`
-    ${theme.button.type.primary}
-    display: inline-block;
-    width: 100%;
-    text-align: center;
-  `}
-`;

--- a/src/components/apply/BackToListLink/BackToListLink.component.tsx
+++ b/src/components/apply/BackToListLink/BackToListLink.component.tsx
@@ -1,0 +1,28 @@
+import { HOME_PAGE, MY_PAGE_APPLY_STATUS, PATH_NAME } from '@/constants';
+import { Application } from '@/types/dto';
+import { useRouter } from 'next/router';
+import * as Styled from './BackToListLink.styled';
+
+interface BackToListLinkProps {
+  application: Application;
+}
+
+const BackToListLink = ({ application }: BackToListLinkProps) => {
+  const router = useRouter();
+  return (
+    <Styled.BackToListLink
+      href={
+        router.pathname === PATH_NAME.APPLY_PAGE
+          ? `/recruit/${application.team.name.toLowerCase()}`
+          : router.pathname === PATH_NAME.MY_PAGE_APPLICATION_DETAIL
+          ? MY_PAGE_APPLY_STATUS
+          : HOME_PAGE
+      }
+    >
+      <Styled.ChevronLeft />
+      <span>목록으로 돌아가기</span>
+    </Styled.BackToListLink>
+  );
+};
+
+export default BackToListLink;

--- a/src/components/apply/BackToListLink/BackToListLink.styled.ts
+++ b/src/components/apply/BackToListLink/BackToListLink.styled.ts
@@ -1,0 +1,34 @@
+import LinkTo from '@/components/common/LinkTo/LinkTo.component';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import ChevronRight7 from '@/assets/svg/chevron-right-7.svg';
+
+export const BackToListLink = styled(LinkTo)`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.medium16};
+    display: inline-block;
+    margin-top: 3.2rem;
+    padding: 0.8rem 1.2rem 0.6rem 0.2rem;
+    border-radius: 0.8rem;
+
+    & > span {
+      vertical-align: middle;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        background: ${theme.colors.gray10};
+      }
+    }
+
+    &:active {
+      background: ${theme.colors.gray10};
+    }
+  `}
+`;
+
+export const ChevronLeft = styled(ChevronRight7)`
+  margin-right: 1.1rem;
+  margin-left: 1rem;
+  transform: rotate(180deg);
+`;

--- a/src/components/apply/BlockingConfirmModalDialog/BlockingConfirmModalDialog.component.tsx
+++ b/src/components/apply/BlockingConfirmModalDialog/BlockingConfirmModalDialog.component.tsx
@@ -1,0 +1,42 @@
+import { ConfirmModalDialog } from '@/components';
+import { usePreventPageChange } from '@/hooks';
+import { useState } from 'react';
+
+interface BlockingConfirmModalDialogProps {
+  isDirty: boolean;
+  isOpenSuccessSubmittedModal: boolean;
+  isTempSaved: boolean;
+}
+
+const BlockingConfirmModalDialog = ({
+  isDirty,
+  isOpenSuccessSubmittedModal,
+  isTempSaved,
+}: BlockingConfirmModalDialogProps) => {
+  const [isOpenBlockingConfirmModal, setIsOpenBlockingConfirmModal] = useState(false);
+
+  const { handleMoveAfterBlocking } = usePreventPageChange(setIsOpenBlockingConfirmModal, [
+    isOpenBlockingConfirmModal,
+    isOpenSuccessSubmittedModal,
+    !isDirty,
+    isTempSaved,
+  ]);
+
+  const handleCloseBlockingConfirmModal = () => {
+    setIsOpenBlockingConfirmModal(false);
+  };
+
+  return isOpenBlockingConfirmModal ? (
+    <ConfirmModalDialog
+      approvalButtonMessage="나가기"
+      cancelButtonMessage="머물기"
+      handleApprovalButton={handleMoveAfterBlocking}
+      handleCancelButton={handleCloseBlockingConfirmModal}
+      heading="지금..나가시게요..?"
+      paragraph="저장 안된 내용은..날아갈 수 있다능.."
+      setIsOpenModal={setIsOpenBlockingConfirmModal}
+    />
+  ) : null;
+};
+
+export default BlockingConfirmModalDialog;

--- a/src/components/apply/PersonalInfoAgree/PersonalInfoAgree.component.tsx
+++ b/src/components/apply/PersonalInfoAgree/PersonalInfoAgree.component.tsx
@@ -1,0 +1,34 @@
+import { LabeledCheckbox } from '@/components';
+import { UseFormReturn } from 'react-hook-form';
+import {
+  ApplyFormValues,
+  APPLY_FORM_KEYS,
+} from '../PersonalInformation/PersonalInformation.component';
+
+interface PersonalInfoAgreeProps {
+  applyForm: UseFormReturn<ApplyFormValues, object>;
+  isDetailPageAndSubmitted: boolean;
+}
+
+const PersonalInfoAgree = ({ applyForm, isDetailPageAndSubmitted }: PersonalInfoAgreeProps) => {
+  const { register, watch } = applyForm;
+  return (
+    <LabeledCheckbox
+      {...register(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+      checked={isDetailPageAndSubmitted ? true : watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+      id={APPLY_FORM_KEYS.isAgreePersonalInfo}
+      disabled={isDetailPageAndSubmitted}
+    >
+      <a
+        href="https://snow-chestnut-45b.notion.site/Mash-Up-Recruit-d4d1eccd3e504bcba575d6e5a95cf1b1"
+        target="_blank"
+        rel="noreferrer"
+      >
+        개인정보 수집 및 이용
+      </a>
+      에 동의합니다.
+    </LabeledCheckbox>
+  );
+};
+
+export default PersonalInfoAgree;

--- a/src/components/apply/PersonalInformation/PersonalInformation.component.tsx
+++ b/src/components/apply/PersonalInformation/PersonalInformation.component.tsx
@@ -1,0 +1,258 @@
+import { LabeledInput } from '@/components';
+import { KeyOf } from '@/types';
+import { Applicant } from '@/types/dto';
+import { validateForm } from '@/utils/reactHookForm';
+import { isValidDate } from '@/utils/validDateString';
+import { unescape } from 'lodash-es';
+import { ChangeEventHandler } from 'react';
+import { Controller, FieldValues, UseFormReturn } from 'react-hook-form';
+import * as Styled from './PersonalInformation.styled';
+
+export interface ApplyFormValues extends FieldValues {
+  userName: string;
+  email: string;
+  phone: string;
+  birthdate: string;
+  residence: string;
+  department: string;
+  isAgreePersonalInfo: boolean;
+}
+
+export const APPLY_FORM_KEYS = {
+  userName: 'userName',
+  email: 'email',
+  phone: 'phone',
+  birthdate: 'birthdate',
+  residence: 'residence',
+  department: 'department',
+  isAgreePersonalInfo: 'isAgreePersonalInfo',
+} as const;
+
+interface PersonalInformationProps {
+  applicant: Applicant;
+  applyForm: UseFormReturn<ApplyFormValues, object>;
+  isDetailPageAndSubmitted: boolean;
+}
+
+const PersonalInformation = ({
+  applicant,
+  applyForm,
+  isDetailPageAndSubmitted,
+}: PersonalInformationProps) => {
+  const {
+    control,
+    register,
+    trigger,
+    setValue,
+    formState: { errors },
+  } = applyForm;
+
+  const handleReplacePhoneNumber: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
+    const onlyNumberReg = /[^0-9]/g;
+
+    if (onlyNumberReg.exec(currentTarget.value)) {
+      setValue(APPLY_FORM_KEYS.phone, currentTarget.value.replace(onlyNumberReg, ''));
+    }
+
+    const restNumber = currentTarget.value.slice(3);
+    const phoneNumberArr = [
+      currentTarget.value.slice(0, 3),
+      restNumber.slice(0, 4),
+      restNumber.slice(4),
+    ];
+
+    const replacedPhoneNumber = phoneNumberArr.filter((isEmptyStr) => isEmptyStr).join('-');
+
+    setValue(APPLY_FORM_KEYS.phone, replacedPhoneNumber);
+  };
+
+  const handleReplaceLocalDate: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) => {
+    const onlyNumberReg = /[^0-9]/g;
+
+    if (onlyNumberReg.exec(currentTarget.value)) {
+      setValue(APPLY_FORM_KEYS.birthdate, currentTarget.value.replace(onlyNumberReg, ''));
+    }
+
+    const restNumber = currentTarget.value.slice(4);
+    const localDateArr = [
+      currentTarget.value.slice(0, 4),
+      restNumber.slice(0, 2),
+      restNumber.slice(2),
+    ];
+
+    const replacedLocalDate = localDateArr.filter((isEmptyStr) => isEmptyStr).join('-');
+
+    setValue(APPLY_FORM_KEYS.birthdate, replacedLocalDate);
+  };
+
+  const handleValidForm = (applyFormKey: KeyOf<typeof APPLY_FORM_KEYS>) => {
+    validateForm<ApplyFormValues>(trigger, applyFormKey);
+  };
+
+  return (
+    <Styled.PersonalInformationSection>
+      <Styled.SectionHeading>개인 정보</Styled.SectionHeading>
+
+      <Styled.PersonalInformationWrapper>
+        <Controller
+          name={APPLY_FORM_KEYS.userName}
+          control={control}
+          rules={{
+            required: '이름은 필수로 입력해야 해요!',
+            maxLength: 24,
+          }}
+          defaultValue={unescape(applicant.name)}
+          render={({ field }) => (
+            <LabeledInput
+              {...field}
+              onChange={({ target }) => {
+                if (target.value.length > 24) return;
+                field.onChange(target.value);
+              }}
+              isError={!!errors.userName}
+              errorMessage={errors.userName?.message}
+              id={APPLY_FORM_KEYS.userName}
+              placeholder="내용을 입력해주세요"
+              label="이름"
+              required
+              disabled={isDetailPageAndSubmitted}
+              $size="md"
+              onBlur={() => {
+                handleValidForm(APPLY_FORM_KEYS.userName);
+              }}
+            />
+          )}
+        />
+      </Styled.PersonalInformationWrapper>
+
+      <Styled.PersonalInformationWrapper>
+        <LabeledInput
+          {...register(APPLY_FORM_KEYS.phone, {
+            required: '전화번호는 필수로 입력해야 해요!',
+            pattern: {
+              value: /^010-\d{3,4}-\d{4}$/,
+              message: '전화번호 형식이 올바르지 않습니다.',
+            },
+            value: applicant.phoneNumber,
+          })}
+          maxLength={13}
+          type="tel"
+          onChange={handleReplacePhoneNumber}
+          id={APPLY_FORM_KEYS.phone}
+          placeholder="전화번호를 입력해주세요"
+          label="전화번호"
+          required
+          disabled={isDetailPageAndSubmitted}
+          isError={!!errors.phone}
+          errorMessage={errors.phone?.message}
+          $size="md"
+          onBlur={() => {
+            handleValidForm(APPLY_FORM_KEYS.phone);
+          }}
+        />
+      </Styled.PersonalInformationWrapper>
+
+      <Styled.PersonalInformationWrapper>
+        <LabeledInput
+          id={APPLY_FORM_KEYS.email}
+          value={unescape(applicant.email)}
+          disabled
+          label="이메일"
+          $size="md"
+          required
+          type="email"
+        />
+      </Styled.PersonalInformationWrapper>
+
+      <Styled.PersonalInformationWrapper>
+        <LabeledInput
+          {...register(APPLY_FORM_KEYS.birthdate, {
+            required: '생년월일은 필수로 입력해야 해요!',
+            value: applicant.birthdate,
+            validate: (value) => isValidDate(value) || '생년월일 형식이 올바르지 않습니다.',
+          })}
+          maxLength={10}
+          type="text"
+          onChange={handleReplaceLocalDate}
+          id={APPLY_FORM_KEYS.birthdate}
+          placeholder="생년월일을 입력해주세요 ex) 2000-01-15"
+          label="생년월일"
+          required
+          disabled={isDetailPageAndSubmitted}
+          isError={!!errors.birthdate}
+          errorMessage={errors.birthdate?.message}
+          $size="md"
+          onBlur={() => {
+            handleValidForm(APPLY_FORM_KEYS.birthdate);
+          }}
+        />
+      </Styled.PersonalInformationWrapper>
+
+      <Styled.PersonalInformationWrapper>
+        <Controller
+          name={APPLY_FORM_KEYS.residence}
+          control={control}
+          rules={{
+            required: '거주지역은 필수로 입력해야 해요!',
+            maxLength: 30,
+          }}
+          defaultValue={unescape(applicant.residence)}
+          render={({ field }) => (
+            <LabeledInput
+              {...field}
+              onChange={({ target }) => {
+                if (target.value.length > 30) return;
+                field.onChange(target.value);
+              }}
+              isError={!!errors.residence}
+              errorMessage={errors.residence?.message}
+              id={APPLY_FORM_KEYS.residence}
+              placeholder="거주지역을 입력해주세요 ex) 서울시 강남구"
+              label="거주지역"
+              required
+              disabled={isDetailPageAndSubmitted}
+              $size="md"
+              onBlur={() => {
+                handleValidForm(APPLY_FORM_KEYS.residence);
+              }}
+            />
+          )}
+        />
+      </Styled.PersonalInformationWrapper>
+
+      <Styled.PersonalInformationWrapper>
+        <Controller
+          name={APPLY_FORM_KEYS.department}
+          control={control}
+          rules={{
+            required: '소속은 필수로 입력해야 해요!',
+            maxLength: 50,
+          }}
+          defaultValue={unescape(applicant.department)}
+          render={({ field }) => (
+            <LabeledInput
+              {...field}
+              onChange={({ target }) => {
+                if (target.value.length > 50) return;
+                field.onChange(target.value);
+              }}
+              isError={!!errors.department}
+              errorMessage={errors.department?.message}
+              id={APPLY_FORM_KEYS.department}
+              placeholder="소속을 입력해주세요 ex) 회사, 학교, 취준생..."
+              label="소속"
+              required
+              disabled={isDetailPageAndSubmitted}
+              $size="md"
+              onBlur={() => {
+                handleValidForm(APPLY_FORM_KEYS.department);
+              }}
+            />
+          )}
+        />
+      </Styled.PersonalInformationWrapper>
+    </Styled.PersonalInformationSection>
+  );
+};
+
+export default PersonalInformation;

--- a/src/components/apply/PersonalInformation/PersonalInformation.styled.ts
+++ b/src/components/apply/PersonalInformation/PersonalInformation.styled.ts
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const PersonalInformationSection = styled.section`
+  margin-top: 6rem;
+`;
+
+export const SectionHeading = styled.h4`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold24};
+    margin-bottom: 2.4rem;
+    color: ${theme.colors.gray80};
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold22}
+    }
+  `}
+`;
+
+export const PersonalInformationWrapper = styled.div`
+  width: 100%;
+  max-width: 53.2rem;
+  margin-bottom: 3.6rem;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+`;

--- a/src/components/apply/QuestionAndAnswerList/QuestionAndAnswerList.component.tsx
+++ b/src/components/apply/QuestionAndAnswerList/QuestionAndAnswerList.component.tsx
@@ -1,0 +1,139 @@
+import { LabeledInput, LabeledTextArea } from '@/components/common';
+import { Question } from '@/types/dto';
+import { validateForm } from '@/utils/reactHookForm';
+import { unescape } from 'lodash-es';
+import { Controller, UseFormReturn } from 'react-hook-form';
+import { ApplyFormValues } from '../PersonalInformation/PersonalInformation.component';
+import * as Styled from './QuestionAndAnswerList.styled';
+
+export interface QuestionAndAnswer {
+  question: Question;
+  answer: {
+    content: string;
+    answerId: number;
+    questionId: number;
+  };
+}
+
+interface QuestionAndAnswerProps {
+  questionsAndAnswers: QuestionAndAnswer[];
+  applyForm: UseFormReturn<ApplyFormValues, object>;
+  isDetailPageAndSubmitted: boolean;
+}
+
+const QuestionAndAnswerList = ({
+  questionsAndAnswers,
+  applyForm,
+  isDetailPageAndSubmitted,
+}: QuestionAndAnswerProps) => {
+  const {
+    control,
+    watch,
+    trigger,
+    formState: { errors },
+  } = applyForm;
+
+  const handleValidForm = (applyFormKey: string) => {
+    validateForm<ApplyFormValues>(trigger, applyFormKey);
+  };
+  return (
+    <Styled.QuestionListSection>
+      <Styled.SectionHeading>질문 목록</Styled.SectionHeading>
+      {questionsAndAnswers?.map(({ question, answer }, index) => {
+        const uniqueQuestionId = `question-${question.questionId}`;
+        return (
+          <Styled.QuestionWrapper key={uniqueQuestionId}>
+            {question.questionType === 'MULTI_LINE_TEXT' ? (
+              <Controller
+                name={uniqueQuestionId}
+                control={control}
+                rules={{
+                  required: {
+                    value: question.required,
+                    message: '필수로 입력해야하는 항목이에요!',
+                  },
+                  maxLength: {
+                    value: question.maxContentLength || 10000,
+                    message: '최대 글자수를 초과하였습니다.',
+                  },
+                }}
+                defaultValue={unescape(answer?.content)}
+                render={({ field }) => (
+                  <LabeledTextArea
+                    {...field}
+                    onChange={({ target }) => {
+                      const { maxContentLength } = question;
+                      if (!maxContentLength && target.value.length > 10000) return;
+
+                      if (maxContentLength && maxContentLength < target.value.length) return;
+
+                      field.onChange(target.value);
+                    }}
+                    label={`${index + 1}. ${question.content}`}
+                    placeholder="내용을 입력해주세요."
+                    required={question.required}
+                    disabled={isDetailPageAndSubmitted}
+                    id={uniqueQuestionId}
+                    isError={!!errors[uniqueQuestionId]}
+                    errorMessage={errors[uniqueQuestionId]?.message}
+                    onBlur={() => {
+                      handleValidForm(uniqueQuestionId);
+                    }}
+                    currentLength={watch(uniqueQuestionId)?.length}
+                    maxContentLength={question.maxContentLength}
+                    description={question.description}
+                  />
+                )}
+              />
+            ) : (
+              <Controller
+                name={uniqueQuestionId}
+                control={control}
+                rules={{
+                  required: {
+                    value: question.required,
+                    message: '필수로 입력해야하는 항목이에요!',
+                  },
+                  maxLength: {
+                    value: question.maxContentLength || 10000,
+                    message: '최대 글자수를 초과하였습니다.',
+                  },
+                }}
+                defaultValue={unescape(answer?.content)}
+                render={({ field }) => (
+                  <LabeledInput
+                    {...field}
+                    onChange={({ target }) => {
+                      const { maxContentLength } = question;
+                      if (!maxContentLength && target.value.length > 10000) return;
+
+                      if (maxContentLength && maxContentLength < target.value.length) return;
+
+                      field.onChange(target.value);
+                    }}
+                    id={uniqueQuestionId}
+                    label={`${index + 1}. ${question.content}`}
+                    required={question.required}
+                    disabled={isDetailPageAndSubmitted}
+                    $size="md"
+                    placeholder="내용을 입력해주세요."
+                    isError={!!errors[uniqueQuestionId]}
+                    errorMessage={errors[uniqueQuestionId]?.message}
+                    onBlur={() => {
+                      handleValidForm(uniqueQuestionId);
+                    }}
+                    currentLength={watch(uniqueQuestionId)?.length}
+                    maxContentLength={question.maxContentLength}
+                    description={question.description}
+                  />
+                )}
+              />
+            )}
+          </Styled.QuestionWrapper>
+        );
+      })}
+    </Styled.QuestionListSection>
+  );
+};
+
+export default QuestionAndAnswerList;

--- a/src/components/apply/QuestionAndAnswerList/QuestionAndAnswerList.styled.ts
+++ b/src/components/apply/QuestionAndAnswerList/QuestionAndAnswerList.styled.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const SectionHeading = styled.h4`
+  ${({ theme }) => css`
+    ${theme.fonts.kr.bold24};
+    margin-bottom: 2.4rem;
+    color: ${theme.colors.gray80};
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold22}
+    }
+  `}
+`;
+
+export const QuestionListSection = styled.section`
+  margin-top: 6rem;
+`;
+
+export const QuestionWrapper = styled.div`
+  margin-bottom: 3.6rem;
+`;

--- a/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
+++ b/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
@@ -98,7 +98,7 @@ const SubmitModalDialog = ({
       {isOpenSuccessSubmittedModal && (
         <ConfirmModalDialog
           heading="지원서 제출 완료!"
-          paragraph="귀한 시간내어 매쉬업 12기에 지원해주셔서 진심으로 감사드립니다! 4월 3일(일) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
+          paragraph="귀한 시간내어 매쉬업 13기에 지원해주셔서 진심으로 감사드립니다! 1월 30일(월) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
           approvalButtonMessage="내 지원서 확인하기"
           cancelButtonMessage="홈으로"
           setIsOpenModal={setIsOpenSuccessSubmittedModal}

--- a/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
+++ b/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
@@ -1,0 +1,131 @@
+import { AlertModalDialog, ConfirmModalDialog } from '@/components';
+import { useSession } from 'next-auth/react';
+import { Dispatch, MutableRefObject, SetStateAction, useState } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { applicationApiService } from '@/api/services';
+import { useRouter } from 'next/router';
+import { HOME_PAGE, MY_PAGE_APPLY_STATUS } from '@/constants';
+import { ApplyFormValues } from '../PersonalInformation/PersonalInformation.component';
+import { QuestionAndAnswer } from '../QuestionAndAnswerList/QuestionAndAnswerList.component';
+
+interface SubmitModalDialogProps {
+  applyForm: UseFormReturn<ApplyFormValues, object>;
+  isOpenConfirmSubmittedModal: boolean;
+  isOpenSuccessSubmittedModal: boolean;
+  questionsAndAnswers: QuestionAndAnswer[];
+  setIsRequesting: Dispatch<SetStateAction<boolean>>;
+  applicationId: number;
+  setIsOpenConfirmSubmittedModal: Dispatch<SetStateAction<boolean>>;
+  setIsOpenSuccessSubmittedModal: Dispatch<SetStateAction<boolean>>;
+  setIsTempSaved: Dispatch<SetStateAction<boolean>>;
+  submitButtonRef: MutableRefObject<HTMLButtonElement>;
+}
+
+const SubmitModalDialog = ({
+  isOpenConfirmSubmittedModal,
+  isOpenSuccessSubmittedModal,
+  applyForm,
+  questionsAndAnswers,
+  setIsRequesting,
+  applicationId,
+  setIsOpenConfirmSubmittedModal,
+  setIsOpenSuccessSubmittedModal,
+  setIsTempSaved,
+  submitButtonRef,
+}: SubmitModalDialogProps) => {
+  const session = useSession();
+  const router = useRouter();
+  const { watch } = applyForm;
+
+  const [isOpenFailedSubmittedModal, setIsOpenFailedSubmittedModal] = useState(false);
+
+  const handleSubmitApplication = async () => {
+    if (session.status === 'unauthenticated') return;
+
+    const { userName, phone, isAgreePersonalInfo, birthdate, department, residence } = watch();
+
+    const applicationSubmitRequest = {
+      applicantName: userName,
+      phoneNumber: phone,
+      privacyPolicyAgreed: isAgreePersonalInfo,
+      birthdate,
+      department,
+      residence,
+      answers: questionsAndAnswers.map(({ question, answer }) => {
+        const uniqueQuestionId = `question-${question.questionId}`;
+
+        return {
+          answerId: answer.answerId,
+          questionId: question.questionId,
+          content: watch(uniqueQuestionId),
+        };
+      }),
+    };
+
+    setIsRequesting(true);
+
+    try {
+      await applicationApiService.submitApplication({
+        accessToken: session.data?.accessToken,
+        applicationId,
+        applicationSubmitRequest,
+      });
+
+      setIsRequesting(false);
+      setIsOpenConfirmSubmittedModal(false);
+      setIsOpenSuccessSubmittedModal(true);
+    } catch (error) {
+      setIsRequesting(false);
+      setIsOpenConfirmSubmittedModal(false);
+      setIsOpenFailedSubmittedModal(true);
+    }
+  };
+
+  return (
+    <>
+      {isOpenConfirmSubmittedModal && (
+        <ConfirmModalDialog
+          heading="지원서를 제출하시겠어요?"
+          paragraph="제출하시면 더 이상 지원서를 수정하거나 삭제할 수 없으며, 중복 지원은 불가한 점 참고 부탁드립니다. 지원 관련 문의는 채널톡으로 해주시면 됩니다."
+          approvalButtonMessage="제출하기"
+          cancelButtonMessage="취소"
+          handleApprovalButton={handleSubmitApplication}
+          handleCancelButton={() => setIsOpenConfirmSubmittedModal(false)}
+          setIsOpenModal={setIsOpenConfirmSubmittedModal}
+          beforeRef={submitButtonRef}
+        />
+      )}
+      {isOpenSuccessSubmittedModal && (
+        <ConfirmModalDialog
+          heading="지원서 제출 완료!"
+          paragraph="귀한 시간내어 매쉬업 12기에 지원해주셔서 진심으로 감사드립니다! 4월 3일(일) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
+          approvalButtonMessage="내 지원서 확인하기"
+          cancelButtonMessage="홈으로"
+          setIsOpenModal={setIsOpenSuccessSubmittedModal}
+          handleCancelButton={() => router.push(HOME_PAGE)}
+          handleApprovalButton={() => {
+            router.push(MY_PAGE_APPLY_STATUS);
+            setIsTempSaved(true);
+            setIsOpenSuccessSubmittedModal(false);
+          }}
+          escClose={false}
+          deemClose={false}
+        />
+      )}
+      {isOpenFailedSubmittedModal && (
+        <AlertModalDialog
+          heading="지원서 제출 실패"
+          paragraph="다시 시도해주세요! 계속 제출하기가 실패된다면 매쉬업 채널톡으로 문의해주세요!"
+          beforeRef={submitButtonRef}
+          setIsOpenModal={setIsOpenFailedSubmittedModal}
+          handleApprovalButton={() => setIsOpenFailedSubmittedModal(false)}
+          escClose={false}
+          deemClose={false}
+          isError
+        />
+      )}
+    </>
+  );
+};
+
+export default SubmitModalDialog;

--- a/src/components/apply/SubmittedButton/SubmittedButton.component.tsx
+++ b/src/components/apply/SubmittedButton/SubmittedButton.component.tsx
@@ -1,0 +1,21 @@
+import { Application } from '@/types/dto';
+import * as Styled from './SubmittedButton.styled';
+
+interface SubmittedButtonProps {
+  application: Application;
+  isCurrentlyOnDetailPage: boolean;
+}
+
+const SubmittedButton = ({ application, isCurrentlyOnDetailPage }: SubmittedButtonProps) => {
+  return isCurrentlyOnDetailPage && application.status === 'SUBMITTED' ? (
+    <Styled.SubmittedCompletedButton type="button" disabled>
+      제출 완료된 지원서 입니다
+    </Styled.SubmittedCompletedButton>
+  ) : (
+    <Styled.AlreadySubmittedButton type="button" disabled>
+      이미 제출한 지원서가 있습니다
+    </Styled.AlreadySubmittedButton>
+  );
+};
+
+export default SubmittedButton;

--- a/src/components/apply/SubmittedButton/SubmittedButton.styled.ts
+++ b/src/components/apply/SubmittedButton/SubmittedButton.styled.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const AlreadySubmittedButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.primary}
+    display: inline-block;
+    width: 100%;
+    text-align: center;
+  `}
+`;
+
+export const SubmittedCompletedButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.primary}
+    display: inline-block;
+    width: 100%;
+    text-align: center;
+  `}
+`;

--- a/src/components/apply/TempSaveAndSubmitButton/TempSaveAndSubmitButton.component.tsx
+++ b/src/components/apply/TempSaveAndSubmitButton/TempSaveAndSubmitButton.component.tsx
@@ -1,0 +1,116 @@
+import { applicationApiService } from '@/api/services';
+import { useSession } from 'next-auth/react';
+import { Dispatch, MouseEventHandler, MutableRefObject, SetStateAction } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import {
+  ApplyFormValues,
+  APPLY_FORM_KEYS,
+} from '../PersonalInformation/PersonalInformation.component';
+import { QuestionAndAnswer } from '../QuestionAndAnswerList/QuestionAndAnswerList.component';
+import * as Styled from './TempSaveAndSubmitButton.styled';
+
+interface TempSaveAndSubmitButtonRefs {
+  tempSaveButtonRef: MutableRefObject<HTMLButtonElement>;
+  submitButtonRef: MutableRefObject<HTMLButtonElement>;
+}
+
+interface TempSaveAndSubmitButtonProps {
+  refs: TempSaveAndSubmitButtonRefs;
+  applyForm: UseFormReturn<ApplyFormValues, object>;
+  applicationId: number;
+  questionsAndAnswers: QuestionAndAnswer[];
+  setIsRequesting: Dispatch<SetStateAction<boolean>>;
+  setIsOpenTempSaveSuccessAlertModal: Dispatch<SetStateAction<boolean>>;
+  setIsOpenTempSaveFailedAlertModal: Dispatch<SetStateAction<boolean>>;
+  setIsTempSaved: Dispatch<SetStateAction<boolean>>;
+}
+
+const TempSaveAndSubmitButton = ({
+  refs,
+  applyForm,
+  applicationId,
+  questionsAndAnswers,
+  setIsRequesting,
+  setIsOpenTempSaveSuccessAlertModal,
+  setIsOpenTempSaveFailedAlertModal,
+  setIsTempSaved,
+}: TempSaveAndSubmitButtonProps) => {
+  const session = useSession();
+  const { submitButtonRef, tempSaveButtonRef } = refs;
+  const { setFocus, trigger, watch } = applyForm;
+
+  const handleTempSaveApplication: MouseEventHandler<HTMLButtonElement> = async () => {
+    if (session.status === 'unauthenticated') return;
+
+    const { userName, phone, isAgreePersonalInfo, birthdate, department, residence } = watch();
+
+    if (!(await trigger(APPLY_FORM_KEYS.userName))) {
+      setFocus(APPLY_FORM_KEYS.userName);
+      return;
+    }
+
+    if (!(await trigger(APPLY_FORM_KEYS.phone))) {
+      setFocus(APPLY_FORM_KEYS.phone);
+      return;
+    }
+
+    if (!(await trigger(APPLY_FORM_KEYS.birthdate))) {
+      setFocus(APPLY_FORM_KEYS.birthdate);
+      return;
+    }
+
+    const updateApplicationRequest = {
+      applicantName: userName,
+      phoneNumber: phone,
+      privacyPolicyAgreed: isAgreePersonalInfo,
+      birthdate,
+      department,
+      residence,
+      answers: questionsAndAnswers.map(({ question, answer }) => {
+        const uniqueQuestionId = `question-${question.questionId}`;
+
+        return {
+          answerId: answer.answerId,
+          questionId: question.questionId,
+          content: watch(uniqueQuestionId),
+        };
+      }),
+    };
+
+    setIsRequesting(true);
+    try {
+      await applicationApiService.tempSaveApplication({
+        accessToken: session.data?.accessToken,
+        applicationId,
+        updateApplicationRequest,
+      });
+
+      setIsRequesting(false);
+      setIsOpenTempSaveSuccessAlertModal(true);
+      setIsTempSaved(true);
+    } catch (error) {
+      setIsRequesting(false);
+      setIsOpenTempSaveFailedAlertModal(true);
+    }
+  };
+  return (
+    <>
+      <Styled.TempSaveButton
+        type="button"
+        disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+        onClick={handleTempSaveApplication}
+        ref={tempSaveButtonRef}
+      >
+        임시저장하기
+      </Styled.TempSaveButton>
+      <Styled.SubmitButton
+        disabled={!watch(APPLY_FORM_KEYS.isAgreePersonalInfo)}
+        ref={submitButtonRef}
+      >
+        제출하기
+      </Styled.SubmitButton>
+    </>
+  );
+};
+
+export default TempSaveAndSubmitButton;

--- a/src/components/apply/TempSaveAndSubmitButton/TempSaveAndSubmitButton.styled.ts
+++ b/src/components/apply/TempSaveAndSubmitButton/TempSaveAndSubmitButton.styled.ts
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const SubmitButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.primary}
+    width: 20rem;
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 100%;
+      margin-right: 0;
+    }
+  `}
+`;
+
+export const TempSaveButton = styled.button`
+  ${({ theme }) => css`
+    ${theme.button.type.primaryLine}
+    width: 20rem;
+    margin-right: 1.6rem;
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 100%;
+      margin-right: 0;
+      margin-bottom: 1.6rem;
+    }
+  `}
+`;

--- a/src/components/apply/TempSaveModalDialog/TempSaveModalDialog.component.tsx
+++ b/src/components/apply/TempSaveModalDialog/TempSaveModalDialog.component.tsx
@@ -1,0 +1,56 @@
+import { AlertModalDialog } from '@/components';
+import { MY_PAGE_APPLY_STATUS } from '@/constants';
+import { useRouter } from 'next/router';
+import { Dispatch, MutableRefObject, SetStateAction } from 'react';
+
+interface TempSaveModalDialogProps {
+  isOpenTempSaveSuccessAlertModal: boolean;
+  isOpenTempSaveFailedAlertModal: boolean;
+  setIsOpenTempSaveSuccessAlertModal: Dispatch<SetStateAction<boolean>>;
+  setIsOpenTempSaveFailedAlertModal: Dispatch<SetStateAction<boolean>>;
+  tempSaveButtonRef: MutableRefObject<HTMLButtonElement>;
+}
+
+const TempSaveModalDialog = ({
+  isOpenTempSaveSuccessAlertModal,
+  isOpenTempSaveFailedAlertModal,
+  setIsOpenTempSaveSuccessAlertModal,
+  setIsOpenTempSaveFailedAlertModal,
+  tempSaveButtonRef,
+}: TempSaveModalDialogProps) => {
+  const router = useRouter();
+
+  return (
+    <>
+      {isOpenTempSaveSuccessAlertModal && (
+        <AlertModalDialog
+          beforeRef={tempSaveButtonRef}
+          heading="임시 저장 완료!"
+          paragraph="기간 내에 지원서는 꼭! 잊지말고 제출해주세요!"
+          handleApprovalButton={() => {
+            router.push(MY_PAGE_APPLY_STATUS);
+            setIsOpenTempSaveSuccessAlertModal(false);
+          }}
+          setIsOpenModal={setIsOpenTempSaveSuccessAlertModal}
+          deemClose={false}
+          escClose={false}
+          enterClose={false}
+        />
+      )}
+      {isOpenTempSaveFailedAlertModal && (
+        <AlertModalDialog
+          beforeRef={tempSaveButtonRef}
+          heading="임시 저장 실패"
+          paragraph="다시 시도해주세요! 계속 임시 저장이 실패된다면 매쉬업 채널톡으로 문의해주세요!"
+          handleApprovalButton={() => setIsOpenTempSaveFailedAlertModal(false)}
+          setIsOpenModal={setIsOpenTempSaveFailedAlertModal}
+          deemClose={false}
+          escClose={false}
+          isError
+        />
+      )}
+    </>
+  );
+};
+
+export default TempSaveModalDialog;

--- a/src/components/apply/index.ts
+++ b/src/components/apply/index.ts
@@ -8,3 +8,4 @@ export { default as TempSaveModalDialog } from './TempSaveModalDialog/TempSaveMo
 export { default as BackToListLink } from './BackToListLink/BackToListLink.component';
 export { default as SubmittedButton } from './SubmittedButton/SubmittedButton.component';
 export { default as PersonalInfoAgree } from './PersonalInfoAgree/PersonalInfoAgree.component';
+export { default as TempSaveAndSubmitButton } from './TempSaveAndSubmitButton/TempSaveAndSubmitButton.component';

--- a/src/components/apply/index.ts
+++ b/src/components/apply/index.ts
@@ -6,3 +6,4 @@ export { default as BlockingConfirmModalDialog } from './BlockingConfirmModalDia
 export { default as SubmitModalDialog } from './SubmitModalDialog/SubmitModalDialog.component';
 export { default as TempSaveModalDialog } from './TempSaveModalDialog/TempSaveModalDialog.component';
 export { default as BackToListLink } from './BackToListLink/BackToListLink.component';
+export { default as SubmittedButton } from './SubmittedButton/SubmittedButton.component';

--- a/src/components/apply/index.ts
+++ b/src/components/apply/index.ts
@@ -7,3 +7,4 @@ export { default as SubmitModalDialog } from './SubmitModalDialog/SubmitModalDia
 export { default as TempSaveModalDialog } from './TempSaveModalDialog/TempSaveModalDialog.component';
 export { default as BackToListLink } from './BackToListLink/BackToListLink.component';
 export { default as SubmittedButton } from './SubmittedButton/SubmittedButton.component';
+export { default as PersonalInfoAgree } from './PersonalInfoAgree/PersonalInfoAgree.component';

--- a/src/components/apply/index.ts
+++ b/src/components/apply/index.ts
@@ -5,3 +5,4 @@ export { default as QuestionAndAnswerList } from './QuestionAndAnswerList/Questi
 export { default as BlockingConfirmModalDialog } from './BlockingConfirmModalDialog/BlockingConfirmModalDialog.component';
 export { default as SubmitModalDialog } from './SubmitModalDialog/SubmitModalDialog.component';
 export { default as TempSaveModalDialog } from './TempSaveModalDialog/TempSaveModalDialog.component';
+export { default as BackToListLink } from './BackToListLink/BackToListLink.component';

--- a/src/components/apply/index.ts
+++ b/src/components/apply/index.ts
@@ -1,2 +1,7 @@
 export { default as ApplyForm } from './ApplyForm/ApplyForm.component';
 export { default as ApplyLayout } from './ApplyLayout/ApplyLayout.component';
+export { default as PersonalInformation } from './PersonalInformation/PersonalInformation.component';
+export { default as QuestionAndAnswerList } from './QuestionAndAnswerList/QuestionAndAnswerList.component';
+export { default as BlockingConfirmModalDialog } from './BlockingConfirmModalDialog/BlockingConfirmModalDialog.component';
+export { default as SubmitModalDialog } from './SubmitModalDialog/SubmitModalDialog.component';
+export { default as TempSaveModalDialog } from './TempSaveModalDialog/TempSaveModalDialog.component';

--- a/src/utils/reactHookForm.ts
+++ b/src/utils/reactHookForm.ts
@@ -1,0 +1,9 @@
+import { ValueOf } from '@/types';
+import { FieldValues, UseFormTrigger } from 'react-hook-form';
+
+export const validateForm = <F extends FieldValues>(
+  trigger: UseFormTrigger<F>,
+  formKey: ValueOf<F>,
+) => {
+  trigger(formKey);
+};


### PR DESCRIPTION
## 변경사항

- 초기 작성시 `applyForm.component.tsx` 파일에 존재하는 700줄에 가까운 코드들을 각각 관심사 또는 카테고리별로 분리해주는데 주 목적을 두고 리팩토링 하였습니다. 주 목적은 관심사의 분리를 하기에 앞서 단순히 코드를 읽고 유지보수하는데 좀 더 수월하게 하기 위함입니다.
- `BackToListLink`, `BlockingConfirmModalDialog`, `TempSaveModalDialog`, `SubmitModalDialog`, `PersonalInfoAgree`, `PersonalInformation`, `QuestionAndAnswersList`, `SubmittedButton`, `TempSaveAndSubmitButton` 총 9개의 컴포넌트를 새로 생성하여 기존 코드들을 분리시켜주었습니다.
- 지원서 제출시 보게되는 안내문구를 `12기 -> 13기`, `4월30일(일) -> 1월30일(월)`로 수정해주었습니다.
- 기능상 변경사항은 없습니다.

> applyForm에서 파생된 상태가 현재 분리해준 컴포넌트들이 대부분 사용하고 있어서 props가 과도하게 내려지는 느낌도 있어서 기능 개선때 불편함을 느낀다면 hook을 만들어서 개선해보는 방향으로 리팩토링 해보겠습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
