### PR TITLE
모집 시작 이전, 이후 여부에 따라 선택적으로 노출할 컴포넌트 구현 (RecruitingRemainder)

### DIFF
--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,0 +1,21 @@
+import { HOME_PAGE, PREFIX } from '@/constants';
+import { getRecruitingProgressStatusFromRecruitingPeriod } from '@/utils/date';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const blockedPaths = Object.values(PREFIX);
+
+export function middleware(request: NextRequest) {
+  const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(new Date());
+  const { pathname } = request.nextUrl;
+
+  const isBlockedPath = blockedPaths.find((path) => pathname.includes(path));
+
+  if (isBlockedPath && recruitingProgressStatus === 'PREVIOUS') {
+    const url = request.nextUrl.clone();
+    url.pathname = HOME_PAGE;
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,20 +5,30 @@ import {
   WelcomeHero,
   RecruitingOpenHero,
   RecruitingPeriod,
+  RecruitingRemainder,
 } from '@/components';
+
 import { useAOS } from '@/hooks';
+import { getRecruitingProgressStatusFromRecruitingPeriod } from '@/utils/date';
 
 const Home = () => {
+  const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(new Date());
+
   useAOS();
 
   return (
-    <HomeLayout>
-      <WelcomeHero />
-      <RecruitingOpenHero />
-      <RecruitingPeriod />
-      <RecruitingProcess />
-      <RecruitingDetailNavigation />
-    </HomeLayout>
+    <>
+      {recruitingProgressStatus === 'PREVIOUS' && <RecruitingRemainder />}
+      {recruitingProgressStatus !== 'PREVIOUS' && (
+        <HomeLayout>
+          <WelcomeHero />
+          <RecruitingOpenHero />
+          <RecruitingPeriod />
+          <RecruitingProcess />
+          <RecruitingDetailNavigation />
+        </HomeLayout>
+      )}
+    </>
   );
 };
 

--- a/src/components/common/Footer/Footer.component.tsx
+++ b/src/components/common/Footer/Footer.component.tsx
@@ -6,70 +6,77 @@ import Facebook32 from '@/assets/svg/facebook-32.svg';
 import Instagram32 from '@/assets/svg/instagram-32.svg';
 import { useRouter } from 'next/router';
 import { HOME_PAGE } from '@/constants';
+import { getRecruitingProgressStatusFromRecruitingPeriod } from '@/utils/date';
 import * as Styled from './Footer.styled';
 
 const Footer = () => {
   const { pathname: currentPage } = useRouter();
+  const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(new Date());
   return (
-    <Styled.Footer currentPage={currentPage}>
-      <Styled.FooterInner>
-        <Styled.Copyright currentPage={currentPage}>
-          © Mash-Up 2022. Made in Seoul.
-        </Styled.Copyright>
-        <Styled.ExternalLinkWrapper currentPage={currentPage}>
-          <a
-            href="https://github.com/mash-up-kr/"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="mash up github"
-          >
-            {currentPage === HOME_PAGE ? (
-              <Styled.GithubIconWrapper>
-                <Styled.GithubIconBackground />
-                <Styled.GithubIconDark aria-hidden />
-              </Styled.GithubIconWrapper>
-            ) : (
-              <GithubWhite32 aria-hidden />
-            )}
-          </a>
-          <a href="mailto:recruit.mashup@gmail.com" aria-label="mash up email">
-            <Mail32 aria-hidden />
-          </a>
-          <a
-            href="https://mash-up.tistory.com/"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="mash up tistory"
-          >
-            <Tistory32 aria-hidden />
-          </a>
-          <a
-            href="https://www.behance.net/Mash-Up/"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="mash up behance"
-          >
-            <Behance32 aria-hidden />
-          </a>
-          <a
-            href="https://www.facebook.com/mashupgroup/"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="mash up facebook"
-          >
-            <Facebook32 aria-hidden />
-          </a>
-          <a
-            href="https://www.instagram.com/official_mashup_/"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="mash up instagram"
-          >
-            <Instagram32 aria-hidden />
-          </a>
-        </Styled.ExternalLinkWrapper>
-      </Styled.FooterInner>
-    </Styled.Footer>
+    <>
+      {recruitingProgressStatus === 'PREVIOUS' && null}
+      {recruitingProgressStatus !== 'PREVIOUS' && (
+        <Styled.Footer currentPage={currentPage}>
+          <Styled.FooterInner>
+            <Styled.Copyright currentPage={currentPage}>
+              © Mash-Up 2022. Made in Seoul.
+            </Styled.Copyright>
+            <Styled.ExternalLinkWrapper currentPage={currentPage}>
+              <a
+                href="https://github.com/mash-up-kr/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="mash up github"
+              >
+                {currentPage === HOME_PAGE ? (
+                  <Styled.GithubIconWrapper>
+                    <Styled.GithubIconBackground />
+                    <Styled.GithubIconDark aria-hidden />
+                  </Styled.GithubIconWrapper>
+                ) : (
+                  <GithubWhite32 aria-hidden />
+                )}
+              </a>
+              <a href="mailto:recruit.mashup@gmail.com" aria-label="mash up email">
+                <Mail32 aria-hidden />
+              </a>
+              <a
+                href="https://mash-up.tistory.com/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="mash up tistory"
+              >
+                <Tistory32 aria-hidden />
+              </a>
+              <a
+                href="https://www.behance.net/Mash-Up/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="mash up behance"
+              >
+                <Behance32 aria-hidden />
+              </a>
+              <a
+                href="https://www.facebook.com/mashupgroup/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="mash up facebook"
+              >
+                <Facebook32 aria-hidden />
+              </a>
+              <a
+                href="https://www.instagram.com/official_mashup_/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="mash up instagram"
+              >
+                <Instagram32 aria-hidden />
+              </a>
+            </Styled.ExternalLinkWrapper>
+          </Styled.FooterInner>
+        </Styled.Footer>
+      )}
+    </>
   );
 };
 

--- a/src/components/common/MainNavigation/MainNavigation.component.tsx
+++ b/src/components/common/MainNavigation/MainNavigation.component.tsx
@@ -6,11 +6,13 @@ import Router, { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import ChevronBottom12 from '@/assets/svg/chevron-bottom-12.svg';
 import { colors } from '@/styles';
+import { getRecruitingProgressStatusFromRecruitingPeriod } from '@/utils/date';
 import * as Styled from './MainNavigation.styled';
 
 const MainNavigation = () => {
   const session = useSession();
   const { pathname: currentPage } = useRouter();
+  const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(new Date());
 
   const isSessionLoading = session.status === 'loading';
 
@@ -44,66 +46,71 @@ const MainNavigation = () => {
 
   return (
     <>
-      <Styled.Nav>
-        <Styled.NavList currentPage={currentPage} isSessionLoading={isSessionLoading}>
-          <li>
-            <Styled.ListItemSkeleton
-              color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
-              isLoading={isSessionLoading}
-            >
-              <LinkTo href={`${HOME_PAGE}#${RECRUIT_DETAILS_ID}`}>모집 공고</LinkTo>
-            </Styled.ListItemSkeleton>
-          </li>
-          <li>
-            <Styled.ListItemSkeleton
-              color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
-              isLoading={isSessionLoading}
-            >
-              <LinkTo href={FAQ_COMMON_PAGE}>자주 묻는 질문</LinkTo>
-            </Styled.ListItemSkeleton>
-          </li>
-          <li>
-            <Styled.ListItemSkeleton
-              color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
-              isLoading={isSessionLoading}
-            >
-              {session.status === 'authenticated' ? (
-                <div ref={MyPageTabWrapper}>
-                  <Styled.MyPageButton
-                    type="button"
-                    currentPage={currentPage}
-                    onClick={handleToggleMyPageTab}
-                    isOpenMyPageTab={isOpenMyPageTab}
-                  >
-                    <span>내 페이지</span>
-                    <ChevronBottom12 />
-                  </Styled.MyPageButton>
-                  <MyPageTab
-                    isOpenMyPageTab={isOpenMyPageTab}
-                    setIsOpenMyPageTab={setIsOpenMyPageTab}
-                  />
-                </div>
-              ) : (
-                <Styled.SignInButton
-                  type="button"
-                  currentPage={currentPage}
-                  onClick={handleOpenSignInModal}
-                  ref={loginButtonRef}
+      {recruitingProgressStatus === 'PREVIOUS' && null}
+      {recruitingProgressStatus !== 'PREVIOUS' && (
+        <>
+          <Styled.Nav>
+            <Styled.NavList currentPage={currentPage} isSessionLoading={isSessionLoading}>
+              <li>
+                <Styled.ListItemSkeleton
+                  color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
+                  isLoading={isSessionLoading}
                 >
-                  로그인
-                </Styled.SignInButton>
-              )}
-            </Styled.ListItemSkeleton>
-          </li>
-        </Styled.NavList>
-      </Styled.Nav>
+                  <LinkTo href={`${HOME_PAGE}#${RECRUIT_DETAILS_ID}`}>모집 공고</LinkTo>
+                </Styled.ListItemSkeleton>
+              </li>
+              <li>
+                <Styled.ListItemSkeleton
+                  color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
+                  isLoading={isSessionLoading}
+                >
+                  <LinkTo href={FAQ_COMMON_PAGE}>자주 묻는 질문</LinkTo>
+                </Styled.ListItemSkeleton>
+              </li>
+              <li>
+                <Styled.ListItemSkeleton
+                  color={currentPage === HOME_PAGE ? 'rgba(255, 255, 255, 0.08)' : colors.gray20}
+                  isLoading={isSessionLoading}
+                >
+                  {session.status === 'authenticated' ? (
+                    <div ref={MyPageTabWrapper}>
+                      <Styled.MyPageButton
+                        type="button"
+                        currentPage={currentPage}
+                        onClick={handleToggleMyPageTab}
+                        isOpenMyPageTab={isOpenMyPageTab}
+                      >
+                        <span>내 페이지</span>
+                        <ChevronBottom12 />
+                      </Styled.MyPageButton>
+                      <MyPageTab
+                        isOpenMyPageTab={isOpenMyPageTab}
+                        setIsOpenMyPageTab={setIsOpenMyPageTab}
+                      />
+                    </div>
+                  ) : (
+                    <Styled.SignInButton
+                      type="button"
+                      currentPage={currentPage}
+                      onClick={handleOpenSignInModal}
+                      ref={loginButtonRef}
+                    >
+                      로그인
+                    </Styled.SignInButton>
+                  )}
+                </Styled.ListItemSkeleton>
+              </li>
+            </Styled.NavList>
+          </Styled.Nav>
 
-      {isOpenSignInModal && (
-        <SignInModal
-          type="login"
-          setIsOpenModal={setIsOpenSignInModal}
-          beforeRef={loginButtonRef}
-        />
+          {isOpenSignInModal && (
+            <SignInModal
+              type="login"
+              setIsOpenModal={setIsOpenSignInModal}
+              beforeRef={loginButtonRef}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
+++ b/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
@@ -1,0 +1,63 @@
+import { useRouter } from 'next/router';
+import { useInterval } from '@/hooks';
+import { getDifferenceOfDates, RECRUITMENT_START_KST_DATE } from '@/utils/date';
+import type { DateDifference } from '@/utils/date';
+import { useState, useEffect } from 'react';
+
+import * as Styled from './RecruitingRemainder.styled';
+
+const RecruitingRemainder = () => {
+  const router = useRouter();
+
+  const [difference, setDifference] = useState<DateDifference>(() =>
+    getDifferenceOfDates(new Date(), RECRUITMENT_START_KST_DATE),
+  );
+
+  const [isPreviousDayOfRecruitingStart, isRunOutTimeOfRecruitingStart] = [
+    difference.day === 0 && Object.values(difference).every((value) => value >= 0),
+    difference.day <= -1,
+  ];
+
+  useInterval(
+    () => {
+      const currentDifference = getDifferenceOfDates(new Date(), RECRUITMENT_START_KST_DATE);
+      setDifference(currentDifference);
+    },
+    isPreviousDayOfRecruitingStart ? 1000 : null,
+  );
+
+  useEffect(() => {
+    if (!isRunOutTimeOfRecruitingStart) return;
+    router.reload();
+  }, [isRunOutTimeOfRecruitingStart, router]);
+
+  return (
+    <Styled.Container>
+      <Styled.RemainderContainer>
+        <Styled.Heading>Mash-Up 13기 모집</Styled.Heading>
+        {!isPreviousDayOfRecruitingStart && !isRunOutTimeOfRecruitingStart && (
+          <Styled.Counter>
+            <Styled.D />
+            <Styled.Separator />
+            <Styled.Day>{difference.day}</Styled.Day>
+          </Styled.Counter>
+        )}
+        {isPreviousDayOfRecruitingStart && !isRunOutTimeOfRecruitingStart && (
+          <Styled.Timer>
+            <Styled.Hours>{difference.hour.toString().padStart(2, '0')}</Styled.Hours>
+            <Styled.Colon />
+            <Styled.Minutes>{difference.minute.toString().padStart(2, '0')}</Styled.Minutes>
+            <Styled.Colon />
+            <Styled.Seconds>{difference.second.toString().padStart(2, '0')}</Styled.Seconds>
+          </Styled.Timer>
+        )}
+      </Styled.RemainderContainer>
+      <Styled.SphereContainer>
+        <Styled.BackLight />
+        <Styled.Sphere />
+      </Styled.SphereContainer>
+    </Styled.Container>
+  );
+};
+
+export default RecruitingRemainder;

--- a/src/components/home/RecruitingRemainder/RecruitingRemainder.styled.ts
+++ b/src/components/home/RecruitingRemainder/RecruitingRemainder.styled.ts
@@ -1,0 +1,254 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  ${({ theme }) => css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100vh;
+    margin-top: -8rem;
+    padding-top: 8rem;
+    overflow: hidden;
+    background: ${theme.colors.gray95};
+    user-select: none;
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      margin-top: -6rem;
+      padding-top: 6rem;
+    }
+
+    &::after {
+      position: absolute;
+      bottom: 0;
+      display: block;
+      width: 100%;
+      height: 60rem;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+      content: '';
+
+      @media (max-width: ${theme.breakPoint.media.tabletM}) {
+        height: 40rem;
+      }
+
+      @media (max-width: ${theme.breakPoint.media.mobile}) {
+        height: 20rem;
+      }
+    }
+  `}
+`;
+
+export const RemainderContainer = styled.div`
+  ${({ theme }) => css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: ${theme.zIndex.content};
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      gap: 0.8rem;
+    }
+  `}
+`;
+
+export const Heading = styled.h2`
+  ${({ theme }) => css`
+    color: ${theme.colors.white};
+    ${theme.fonts.kr.bold32};
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      ${theme.fonts.kr.bold24};
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.kr.bold14};
+    }
+  `}
+`;
+
+export const Counter = styled.p`
+  ${({ theme }) => css`
+    ${theme.fonts.en.extrabold300};
+    display: flex;
+    gap: 2.4rem;
+    color: ${theme.colors.white};
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      ${theme.fonts.en.extrabold200};
+      gap: 0.4rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.en.extrabold100};
+      gap: 0.2rem;
+    }
+  `}
+`;
+
+export const D = styled.span`
+  &::after {
+    content: 'D';
+  }
+`;
+
+export const Separator = styled.span`
+  &::after {
+    content: '-';
+  }
+`;
+
+export const Day = styled.span``;
+
+export const Timer = styled.p`
+  ${({ theme }) => css`
+    ${theme.fonts.en.extrabold180};
+    display: flex;
+    gap: 1rem;
+    color: ${theme.colors.white};
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      ${theme.fonts.en.extrabold100};
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      ${theme.fonts.en.extrabold70};
+    }
+  `}
+`;
+
+export const Hours = styled.span`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26rem;
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      width: 14rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 9rem;
+    }
+  `}
+`;
+
+export const Minutes = styled.span`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26rem;
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      width: 14rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 9rem;
+    }
+  `}
+`;
+
+export const Seconds = styled.span`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26rem;
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      width: 14rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 9rem;
+    }
+  `}
+`;
+
+export const Colon = styled.span`
+  &::after {
+    display: block;
+    content: ':';
+  }
+`;
+
+export const SphereContainer = styled.div`
+  ${({ theme }) => css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 63rem;
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      height: 42rem;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      height: 21rem;
+    }
+  `}
+`;
+
+export const BackLight = styled.div`
+  ${({ theme }) => css`
+    position: relative;
+    width: 100rem;
+    height: 50rem;
+    background: linear-gradient(0deg, #ff1c60 36.93%, #5243ff 100%);
+    border-radius: 50rem 50rem 0 0;
+    opacity: 0.8;
+    filter: blur(5.7rem);
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      width: 66.6rem;
+      height: 33.3rem;
+      border-radius: 33.3rem 33.3rem 0 0;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      width: 33.3rem;
+      height: calc(33.3rem / 2);
+      border-radius: calc(33.3rem / 2) calc(33.3rem / 2) 0 0;
+    }
+  `}
+`;
+
+export const Sphere = styled.div`
+  ${({ theme }) => css`
+    position: absolute;
+    top: 6rem;
+    width: 120rem;
+    height: 60rem;
+    background: red;
+    background: linear-gradient(180deg, #2c3265 -3.9%, #000000 20.31%);
+    border-radius: 60rem 60rem 0 0;
+    box-shadow: inset 0 0 5.621rem rgba(101, 75, 204, 0.45);
+
+    @media (max-width: ${theme.breakPoint.media.tabletM}) {
+      top: 4rem;
+      width: 80rem;
+      height: 40rem;
+      border-radius: 40rem 40rem 0 0;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      top: 2rem;
+      width: 40rem;
+      height: 20rem;
+      border-radius: 20rem 20rem 0 0;
+    }
+  `}
+`;

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -5,3 +5,4 @@ export { default as WelcomeHero } from './WelcomeHero/WelcomeHero.component';
 export { default as RecruitingOpenHero } from './RecruitingOpenHero/RecruitingOpenHero.component';
 export { default as RecruitingPeriod } from './RecruitingPeriod/RecruitingPeriod.component';
 export { default as RecruitingPeriodDesktop } from './RecruitingPeriodDesktop/RecruitingPeriodDesktop.component';
+export { default as RecruitingRemainder } from './RecruitingRemainder/RecruitingRemainder.component';

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -6,37 +6,44 @@ export const ERROR_PAGE = '/error';
 export const HOME_PAGE = '/';
 export const RECRUIT_DETAILS_ID = 'recruit-details';
 
-export const APPLY_FRONT_END_PAGE = `/apply/${teamUrls.web}`;
-export const APPLY_DESIGN_PAGE = `/apply/${teamUrls.design}`;
-export const APPLY_NODE_PAGE = `/apply/${teamUrls.node}`;
-export const APPLY_SPRING_PAGE = `/apply/${teamUrls.spring}`;
-export const APPLY_IOS_PAGE = `/apply/${teamUrls.ios}`;
-export const APPLY_ANDROID_PAGE = `/apply/${teamUrls.android}`;
+export const PREFIX = {
+  APPLY: 'apply',
+  FAQ: 'faq',
+  MY_PAGE: 'my-page',
+  RECRUIT: 'recruit',
+};
 
-export const FAQ_COMMON_PAGE = '/faq/common';
-export const FAQ_FRONT_END_PAGE = `/faq/${teamUrls.web}`;
-export const FAQ_DESIGN_PAGE = `/faq/${teamUrls.design}`;
-export const FAQ_NODE_PAGE = `/faq/${teamUrls.node}`;
-export const FAQ_SPRING_PAGE = `/faq/${teamUrls.spring}`;
-export const FAQ_IOS_PAGE = `/faq/${teamUrls.ios}`;
-export const FAQ_ANDROID_PAGE = `/faq/${teamUrls.android}`;
+export const APPLY_FRONT_END_PAGE = `/${PREFIX.APPLY}/${teamUrls.web}`;
+export const APPLY_DESIGN_PAGE = `/${PREFIX.APPLY}/${teamUrls.design}`;
+export const APPLY_NODE_PAGE = `/${PREFIX.APPLY}/${teamUrls.node}`;
+export const APPLY_SPRING_PAGE = `/${PREFIX.APPLY}/${teamUrls.spring}`;
+export const APPLY_IOS_PAGE = `/${PREFIX.APPLY}/${teamUrls.ios}`;
+export const APPLY_ANDROID_PAGE = `/${PREFIX.APPLY}/${teamUrls.android}`;
 
-export const MY_PAGE_ACCOUNT = '/my-page/account';
-export const MY_PAGE_APPLY_STATUS = '/my-page/apply-status';
-export const MY_PAGE_APPLICATION_DETAIL = '/my-page/application-detail'; // 사용시 `/${id}` 넣어줄것 (동적 라우트)
+export const FAQ_COMMON_PAGE = `/${PREFIX.FAQ}/common`;
+export const FAQ_FRONT_END_PAGE = `/${PREFIX.FAQ}/${teamUrls.web}`;
+export const FAQ_DESIGN_PAGE = `/${PREFIX.FAQ}/${teamUrls.design}`;
+export const FAQ_NODE_PAGE = `/${PREFIX.FAQ}/${teamUrls.node}`;
+export const FAQ_SPRING_PAGE = `/${PREFIX.FAQ}/${teamUrls.spring}`;
+export const FAQ_IOS_PAGE = `/${PREFIX.FAQ}/${teamUrls.ios}`;
+export const FAQ_ANDROID_PAGE = `/${PREFIX.FAQ}/${teamUrls.android}`;
 
-export const RECRUIT_FRONT_END_PAGE = `/recruit/${teamUrls.web}`;
-export const RECRUIT_DESIGN_PAGE = `/recruit/${teamUrls.design}`;
-export const RECRUIT_IOS_PAGE = `/recruit/${teamUrls.ios}`;
-export const RECRUIT_ANDROID_PAGE = `/recruit/${teamUrls.android}`;
-export const RECRUIT_NODE_PAGE = `/recruit/${teamUrls.node}`;
-export const RECRUIT_SPRING_PAGE = `/recruit/${teamUrls.spring}`;
+export const MY_PAGE_ACCOUNT = `/${PREFIX.MY_PAGE}/account`;
+export const MY_PAGE_APPLY_STATUS = `/${PREFIX.MY_PAGE}/apply-status`;
+export const MY_PAGE_APPLICATION_DETAIL = `/${PREFIX.MY_PAGE}/application-detail`; // 사용시 `/${id}` 넣어줄것 (동적 라우트)
+
+export const RECRUIT_FRONT_END_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.web}`;
+export const RECRUIT_DESIGN_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.design}`;
+export const RECRUIT_IOS_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.ios}`;
+export const RECRUIT_ANDROID_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.android}`;
+export const RECRUIT_NODE_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.node}`;
+export const RECRUIT_SPRING_PAGE = `/${PREFIX.RECRUIT}/${teamUrls.spring}`;
 
 export const PATH_NAME = {
-  APPLY_PAGE: '/apply/[platformName]',
-  FAQ_PAGE: '/faq/[platformName]',
-  MY_PAGE_ACCOUNT: '/my-page/account',
-  MY_PAGE_APPLY_STATUS: '/my-page/apply-status',
-  MY_PAGE_APPLICATION_DETAIL: '/my-page/application-detail/[applicationId]',
-  RECRUIT_PAGE: '/recruit/[platformName]',
+  APPLY_PAGE: `/${PREFIX.APPLY}/[platformName]`,
+  FAQ_PAGE: `/${PREFIX.FAQ}/[platformName]`,
+  MY_PAGE_ACCOUNT: `/${PREFIX.MY_PAGE}/account`,
+  MY_PAGE_APPLY_STATUS: `/${PREFIX.MY_PAGE}/apply-status`,
+  MY_PAGE_APPLICATION_DETAIL: `/${PREFIX.MY_PAGE}/application-detail/[applicationId]`,
+  RECRUIT_PAGE: `/${PREFIX.RECRUIT}/[platformName]`,
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,4 @@ export { default as useToast } from './useToast';
 export { default as useGoogleAnalytics } from './useGoogleAnalytics';
 export { default as useLoadingModal } from './useLoadingModal';
 export { default as useErrorModalDialog } from './useErrorModalDialog';
+export { default as useInterval } from './useInterval';

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -9,7 +9,7 @@ const useInterval = (callback: Function, delay?: number | null) => {
 
   useEffect(() => {
     if (delay !== null) {
-      const interval = setInterval(() => savedCallback.current(), delay || 0);
+      const interval = setInterval(savedCallback.current, delay || 0);
       return () => clearInterval(interval);
     }
 

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+const useInterval = (callback: Function, delay?: number | null) => {
+  const savedCallback = useRef<Function>(() => {});
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (delay !== null) {
+      const interval = setInterval(() => savedCallback.current(), delay || 0);
+      return () => clearInterval(interval);
+    }
+
+    return undefined;
+  }, [delay]);
+};
+
+export default useInterval;

--- a/src/styles/themes/fonts.ts
+++ b/src/styles/themes/fonts.ts
@@ -65,6 +65,13 @@ export const fonts = {
       line-height: 1.5;
       letter-spacing: -0.08rem;
     `,
+    bold14: css`
+      font-weight: 700;
+      font-size: 1.4rem;
+      font-family: SpoqaHanSansNeo;
+      line-height: 1.5;
+      letter-spacing: -0.08rem;
+    `,
     medium16: css`
       font-weight: 500;
       font-size: 1.6rem;
@@ -123,6 +130,24 @@ export const fonts = {
     `,
   },
   en: {
+    extrabold300: css`
+      font-weight: 800;
+      font-size: 30rem;
+      font-family: Gilroy;
+      line-height: 36.8rem;
+    `,
+    extrabold200: css`
+      font-weight: 800;
+      font-size: 20rem;
+      font-family: Gilroy;
+      line-height: 24.5rem;
+    `,
+    extrabold180: css`
+      font-weight: 800;
+      font-size: 18rem;
+      font-family: Gilroy;
+      line-height: 22.1rem;
+    `,
     extrabold146: css`
       font-weight: 800;
       font-size: 14.6rem;
@@ -140,6 +165,12 @@ export const fonts = {
       font-size: 8rem;
       font-family: Gilroy;
       line-height: 9.8rem;
+    `,
+    extrabold70: css`
+      font-weight: 800;
+      font-size: 7rem;
+      font-family: Gilroy;
+      line-height: 8.6rem;
     `,
     extrabold60: css`
       font-weight: 800;

--- a/src/styles/themes/zIndex.ts
+++ b/src/styles/themes/zIndex.ts
@@ -1,5 +1,6 @@
 export const zIndex = {
   default: 0,
+  content: 1,
   header: 5,
   modal: 10,
   dialog: 15,

--- a/src/styles/themes/zIndex.ts
+++ b/src/styles/themes/zIndex.ts
@@ -1,10 +1,10 @@
 export const zIndex = {
   default: 0,
-  content: 1,
-  header: 5,
-  modal: 10,
-  dialog: 15,
-  toast: 20,
+  content: 5,
+  header: 10,
+  modal: 15,
+  dialog: 20,
+  toast: 25,
 };
 
 export type ZIndexType = typeof zIndex;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,6 @@
+import { KeyOf } from '@/types';
+import { objectKeys } from './object';
+
 const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
 export const [
@@ -72,4 +75,25 @@ export const getValueOfDateIntoObj = (dateInstance: Date) => {
   const dayKr = DAYS[dateInstance.getDay()];
 
   return { month, date, hour24Format, hour12Format, isAfternoon, minute, day, dayKr };
+};
+
+const DATE_DIFFERENCE_DEFINITION = {
+  day: 86400000,
+  hour: 3600000,
+  minute: 60000,
+  second: 1000,
+  millisecond: 1,
+} as const;
+
+const DATE_DIFFERENCE_KEYS = objectKeys(DATE_DIFFERENCE_DEFINITION);
+
+export type DateDifference = Record<KeyOf<typeof DATE_DIFFERENCE_DEFINITION>, number>;
+
+export const getDifferenceOfDates = (startDate: Date, endDate: Date): DateDifference => {
+  let delta = endDate.getTime() - startDate.getTime();
+  return DATE_DIFFERENCE_KEYS.reduce<DateDifference>((dateDifference, key) => {
+    const calculatedValueByKey = Math.floor(delta / DATE_DIFFERENCE_DEFINITION[key]);
+    delta -= calculatedValueByKey * DATE_DIFFERENCE_DEFINITION[key];
+    return Object.assign(dateDifference, { [key]: calculatedValueByKey });
+  }, {} as DateDifference);
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,17 +1,17 @@
 const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
-const [
+export const [
   RECRUITMENT_START_KST_DATE, // 서류 접수 시작
   RECRUITMENT_END_KST_DATE, // 서류 접수 종료
   SCREENING_RESULT_ANNOUNCED_KST_DATE, // 서류 결과 발표
   INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
   AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
 ] = [
-  new Date('2022-03-16T00:00:00+09:00'),
-  new Date('2022-03-29T23:59:59+09:00'),
-  new Date('2022-04-03T10:00:00+09:00'),
-  new Date('2022-04-12T19:00:00+09:00'),
-  new Date('2022-04-16T17:00:00+09:00'),
+  new Date('2023-01-11T00:00:00+09:00'),
+  new Date('2023-01-25T23:59:59+09:00'),
+  new Date('2023-01-30T10:00:00+09:00'),
+  new Date('2023-02-07T19:00:00+09:00'),
+  new Date('2023-02-11T18:00:00+09:00'),
 ];
 
 export type RecruitingProgressStatus =

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,7 +10,7 @@ export const [
   INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
   AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
 ] = [
-  new Date('2023-01-11T00:00:00+09:00'),
+  new Date('2022-12-28T00:00:00+09:00'),
   new Date('2023-01-25T23:59:59+09:00'),
   new Date('2023-01-30T10:00:00+09:00'),
   new Date('2023-02-07T19:00:00+09:00'),


### PR DESCRIPTION
## 변경사항

- Next.js의 middleware를 이용하여 요청이 들어왔을 때 모집 기간 시작 이전인 경우 HOME_PAGE로 리다이렉트 시키고 모집 기간 시작 이후에는 기존 경로에 접근 가능하도록 구현하였습니다.
- 모집 시작 하루 전에는 00:00:00 형태의 카운트다운을 노출하고 하루 이전에는 D-0 형태의 카운터를 노출하도록 구현하였습니다.
- 모집 시작 이후가 되면 Footer와 MainNavigation의 컨텐츠와 기존의 UI가 노출되게끔 구현하였습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
