### PR TITLE
모집 상태 판별 이전의 UI 수정

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,8 +16,9 @@ import { useEffect, useState } from 'react';
 const Home = () => {
   useAOS();
 
-  const [recruitingProgressStatus, setRecruitingProgressStatus] =
-    useState<RecruitingProgressStatus>('INVALID');
+  const [recruitingProgressStatus, setRecruitingProgressStatus] = useState<
+    RecruitingProgressStatus | 'NOT_INITIALIZED'
+  >('NOT_INITIALIZED');
 
   useEffect(() => {
     setRecruitingProgressStatus(getRecruitingProgressStatusFromRecruitingPeriod(new Date()));
@@ -27,7 +28,7 @@ const Home = () => {
     <>
       {recruitingProgressStatus === 'PREVIOUS' && <RecruitingRemainder />}
       {recruitingProgressStatus !== 'PREVIOUS' && (
-        <HomeLayout>
+        <HomeLayout visibility={recruitingProgressStatus !== 'NOT_INITIALIZED'}>
           <WelcomeHero />
           <RecruitingOpenHero />
           <RecruitingPeriod />

--- a/src/components/home/HomeLayout/HomeLayout.component.tsx
+++ b/src/components/home/HomeLayout/HomeLayout.component.tsx
@@ -3,10 +3,11 @@ import * as Styled from './HomeLayout.styled';
 
 interface HomeLayoutProps {
   children: ReactNode;
+  visibility: boolean;
 }
 
-const HomeLayout = ({ children }: HomeLayoutProps) => {
-  return <Styled.Layout>{children}</Styled.Layout>;
+const HomeLayout = ({ children, visibility }: HomeLayoutProps) => {
+  return <Styled.Layout visibility={visibility}>{children}</Styled.Layout>;
 };
 
 export default HomeLayout;

--- a/src/components/home/HomeLayout/HomeLayout.styled.ts
+++ b/src/components/home/HomeLayout/HomeLayout.styled.ts
@@ -1,13 +1,14 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Layout = styled.div`
-  ${({ theme }) => css`
+export const Layout = styled.div<{ visibility: boolean }>`
+  ${({ theme, visibility }) => css`
     min-height: 200vh;
     margin-top: -8rem;
     padding-top: 8rem;
     padding-bottom: 20rem;
     background: ${theme.colors.gray95};
+    visibility: ${visibility};
     user-select: none;
 
     @media (max-width: ${theme.breakPoint.media.tabletL}) {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,7 +10,7 @@ export const [
   INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
   AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
 ] = [
-  new Date('2022-12-28T01:00:00+09:00'),
+  new Date('2022-12-28T20:00:00+09:00'),
   new Date('2023-01-25T23:59:59+09:00'),
   new Date('2023-01-30T10:00:00+09:00'),
   new Date('2023-02-07T19:00:00+09:00'),


### PR DESCRIPTION
## 변경사항

- hydration 이슈를 회피하기 위해 useState와 useEffect를 이용하여 모집 기간 여부를 판별하게 됨에 따라 상태를 얻기 이전의 UI를 제공합니다.
- 기존 UI를 노출하기 이전에 NOT_INITIALIZED라는 상태인지를 추가적으로 검증해 visibility를 결정하도록 변경합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
