### PR TITLE
날짜 렌더링 수정

### DIFF
--- a/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
+++ b/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
@@ -39,7 +39,7 @@ const RecruitingRemainder = () => {
           <Styled.Counter>
             <Styled.D />
             <Styled.Separator />
-            <Styled.Day>{difference.day}</Styled.Day>
+            <Styled.Day>{difference.day + 1}</Styled.Day>
           </Styled.Counter>
         )}
         {isPreviousDayOfRecruitingStart && !isRunOutTimeOfRecruitingStart && (


### PR DESCRIPTION
## 변경사항

- 현재는 N일 N시간 N분 N초 형태로 모집 시작 날짜와의 차이를 구하는 방식이라 실제로 노출되어야 하는 N+1일과 1만큼 차이가 나게 되어 N + 1일로 렌더링하도록 수정합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
