### PR TITLE
Feature/cru application by generation

### DIFF
--- a/pages/apply/[platformName].tsx
+++ b/pages/apply/[platformName].tsx
@@ -5,7 +5,15 @@ import {
   PLATFORM_HEADINGS,
   PLATFORM_ROLE,
 } from '@/components/apply/ApplyLayout/ApplyLayout.component';
-import { ERROR_PAGE, HOME_PAGE, NOT_FOUND_PAGE, teamIds, teamNames, Teams } from '@/constants';
+import {
+  CURRENT_GENERATION,
+  ERROR_PAGE,
+  HOME_PAGE,
+  NOT_FOUND_PAGE,
+  teamIds,
+  teamNames,
+  Teams,
+} from '@/constants';
 import { Application } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -71,16 +79,21 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       })
     ).data;
 
-    const isSubmitted = applications.some(({ status }) => status === 'SUBMITTED');
+    const isSubmitted = applications.some(
+      ({ status, generationResponse: { generationNumber } }) =>
+        status === 'SUBMITTED' && generationNumber === CURRENT_GENERATION,
+    );
 
     const currentApplication = applications.find(
-      ({ team }) => team.teamId === teamIds[currentApplyPlatform],
+      ({ team, generationResponse: { generationNumber } }) =>
+        team.teamId === teamIds[CURRENT_GENERATION][currentApplyPlatform] &&
+        generationNumber === CURRENT_GENERATION,
     );
 
     if (!currentApplication) {
       const application = await applicationApiService.createMyApplication({
         accessToken: session.accessToken,
-        teamId: teamIds[currentApplyPlatform],
+        teamId: teamIds[CURRENT_GENERATION][currentApplyPlatform],
       });
       return {
         props: {

--- a/pages/my-page/application-detail/[applicationId].tsx
+++ b/pages/my-page/application-detail/[applicationId].tsx
@@ -1,6 +1,6 @@
 import { applicationApiService } from '@/api/services';
 import { ApplicationDetailLayout } from '@/components';
-import { ERROR_PAGE, HOME_PAGE } from '@/constants';
+import { CURRENT_GENERATION, ERROR_PAGE, HOME_PAGE } from '@/constants';
 import { Application } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -33,7 +33,10 @@ export const getServerSideProps: GetServerSideProps<ApplicationDetailProps> = as
 
     const applications = applicationsRes.data;
 
-    const isSubmitted = applications.some(({ status }) => status === 'SUBMITTED');
+    const isSubmitted = applications.some(
+      ({ status, generationResponse: { generationNumber } }) =>
+        status === 'SUBMITTED' && generationNumber === CURRENT_GENERATION,
+    );
 
     const application = applications.find(
       ({ applicationId }) =>

--- a/pages/my-page/apply-status.tsx
+++ b/pages/my-page/apply-status.tsx
@@ -2,6 +2,7 @@ import { applicationApiService } from '@/api/services';
 import { ApplyStatusLayout } from '@/components';
 import { ERROR_PAGE, HOME_PAGE } from '@/constants';
 import { Application } from '@/types/dto';
+import { sortByGenerationAndTeam } from '@/utils/application';
 import {
   getRecruitingProgressStatusFromRecruitingPeriod,
   RecruitingProgressStatus,
@@ -38,7 +39,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       accessToken: session.accessToken,
     });
 
-    const applications = applicationsRes.data;
+    const applications = sortByGenerationAndTeam(applicationsRes.data);
 
     const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(new Date());
 

--- a/src/components/apply/ApplyForm/ApplyForm.component.tsx
+++ b/src/components/apply/ApplyForm/ApplyForm.component.tsx
@@ -10,7 +10,7 @@ import {
   PersonalInfoAgree,
   TempSaveAndSubmitButton,
 } from '@/components';
-import { PATH_NAME } from '@/constants';
+import { CURRENT_GENERATION, PATH_NAME } from '@/constants';
 import { Application } from '@/types/dto';
 import { useRouter } from 'next/router';
 import { MutableRefObject, useRef, useState } from 'react';
@@ -37,7 +37,13 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
   const [isOpenConfirmSubmittedModal, setIsOpenConfirmSubmittedModal] = useState(false);
   const [isOpenSuccessSubmittedModal, setIsOpenSuccessSubmittedModal] = useState(false);
 
-  const { questions, applicationId, answers, applicant } = application;
+  const {
+    questions,
+    applicationId,
+    answers,
+    applicant,
+    generationResponse: { generationNumber },
+  } = application;
 
   const questionsAndAnswers = questions.map((question, index) => {
     const questionMatchAnswer =
@@ -81,7 +87,7 @@ const ApplyForm = ({ application, isSubmitted }: ApplyFormProps) => {
           isDetailPageAndSubmitted={isDetailPageAndSubmitted}
         />
         <Styled.ControlSection>
-          {isSubmitted ? (
+          {isSubmitted || generationNumber !== CURRENT_GENERATION ? (
             <SubmittedButton
               application={application}
               isCurrentlyOnDetailPage={isCurrentlyOnDetailPage}

--- a/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
+++ b/src/components/apply/SubmitModalDialog/SubmitModalDialog.component.tsx
@@ -4,7 +4,7 @@ import { Dispatch, MutableRefObject, SetStateAction, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { applicationApiService } from '@/api/services';
 import { useRouter } from 'next/router';
-import { HOME_PAGE, MY_PAGE_APPLY_STATUS } from '@/constants';
+import { CURRENT_GENERATION, HOME_PAGE, MY_PAGE_APPLY_STATUS } from '@/constants';
 import { ApplyFormValues } from '../PersonalInformation/PersonalInformation.component';
 import { QuestionAndAnswer } from '../QuestionAndAnswerList/QuestionAndAnswerList.component';
 
@@ -98,7 +98,7 @@ const SubmitModalDialog = ({
       {isOpenSuccessSubmittedModal && (
         <ConfirmModalDialog
           heading="지원서 제출 완료!"
-          paragraph="귀한 시간내어 매쉬업 13기에 지원해주셔서 진심으로 감사드립니다! 1월 30일(월) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!"
+          paragraph={`귀한 시간내어 매쉬업 ${CURRENT_GENERATION}기에 지원해주셔서 진심으로 감사드립니다! 1월 30일(월) 오전 10시에 내 페이지에서 서류 결과 발표를 꼭 확인해주세요!`}
           approvalButtonMessage="내 지원서 확인하기"
           cancelButtonMessage="홈으로"
           setIsOpenModal={setIsOpenSuccessSubmittedModal}

--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -9,13 +9,11 @@ import {
   FinalConfirmAccept,
   FinalConfirmReject,
 } from '@/components';
-import { AlertModalDialog } from '@/components/common';
 import { Application } from '@/types/dto';
 import { RecruitingProgressStatus } from '@/utils/date';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import * as Styled from './ApplyStatusDetail.styled';
 
-const IS_FIRST_VISIT = 'isFirstVisit';
 interface ApplyStatusDetailProps {
   applications: Application[];
   recruitingProgressStatus: RecruitingProgressStatus;
@@ -25,18 +23,6 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
   const [submittedApplication, setSubmittedApplication] = useState(
     applications.find((application) => application.status === 'SUBMITTED'),
   );
-  const [isOpenResultDelayModal, setIsOpenResultDelayModal] = useState(false);
-
-  useEffect(() => {
-    const { localStorage } = window;
-    if (!localStorage.getItem(IS_FIRST_VISIT)) {
-      setIsOpenResultDelayModal(true);
-    }
-
-    if (localStorage.getItem(IS_FIRST_VISIT) === null) {
-      window.localStorage.setItem(IS_FIRST_VISIT, 'false');
-    }
-  }, []);
 
   if (!submittedApplication || recruitingProgressStatus === 'AFTER-FIRST-SEMINAR') return null;
 
@@ -47,14 +33,6 @@ const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStat
     return (
       <Styled.StatusDetail>
         <ScreeningWait />
-        {isOpenResultDelayModal && (
-          <AlertModalDialog
-            heading="서류 결과는 4월 3일 오전 10시에 발표됩니다"
-            paragraph="이번 12기 모집에 예상보다 많은 분들이 지원해주셔서 기간 내 서류 검토가 어려워 하루 늦어짐을 공지드립니다. 일정 변동된 점 양해 부탁드립니다."
-            handleApprovalButton={() => setIsOpenResultDelayModal(false)}
-            setIsOpenModal={setIsOpenResultDelayModal}
-          />
-        )}
       </Styled.StatusDetail>
     );
   }

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -1,4 +1,4 @@
-import { TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, TEAM_NICK_NAME } from '@/constants';
 import { Application } from '@/types/dto';
 import * as Styled from './FinalConfirmAccept.styled';
 
@@ -12,12 +12,13 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
     <Styled.FinalConfirmAccept>
       <Styled.NoticeSection>
         <Styled.NoticeMessage>
-          {applicant.name}님 환영해요! {'\n'}Mash-Up 12기에서 멋-진 활약 기대합니다!
+          {applicant.name}님 환영해요! {'\n'}Mash-Up {CURRENT_GENERATION}기에서 멋-진 활약
+          기대합니다!
         </Styled.NoticeMessage>
         <Styled.NoticeDetail>
-          안녕하세요 {applicant.name}님! Mash-Up 12기 {TEAM_NICK_NAME[team.name]}과 함께하게 되어
-          너무 기뻐요! 2월 10일 금요일 오후 중으로 Mash-Up 13기 단톡방에 초대해드리겠습니다. 앞으로
-          잘 부탁드립니다!
+          안녕하세요 {applicant.name}님! Mash-Up {CURRENT_GENERATION}기 {TEAM_NICK_NAME[team.name]}
+          과 함께하게 되어 너무 기뻐요! 2월 10일 금요일 오후 중으로 Mash-Up {CURRENT_GENERATION}기
+          단톡방에 초대해드리겠습니다. 앞으로 잘 부탁드립니다!
         </Styled.NoticeDetail>
       </Styled.NoticeSection>
       <Styled.OtDetailSection>

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -16,15 +16,15 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
         </Styled.NoticeMessage>
         <Styled.NoticeDetail>
           안녕하세요 {applicant.name}님! Mash-Up 12기 {TEAM_NICK_NAME[team.name]}과 함께하게 되어
-          너무 기뻐요! 15일 금요일 오후 중으로 Mash-Up 12기 단톡방에 초대해드리겠습니다. 앞으로 잘
-          부탁드립니다!
+          너무 기뻐요! 2월 10일 금요일 오후 중으로 Mash-Up 13기 단톡방에 초대해드리겠습니다. 앞으로
+          잘 부탁드립니다!
         </Styled.NoticeDetail>
       </Styled.NoticeSection>
       <Styled.OtDetailSection>
         <Styled.OtDetailHeading>Mash-Up OT일시</Styled.OtDetailHeading>
-        <Styled.OtDetailContent>4월 16일(토) 오후 2시 ~ 5시 [ZOOM]</Styled.OtDetailContent>
+        <Styled.OtDetailContent>2월 11일(토) 오후 2시 ~ 5시</Styled.OtDetailContent>
         <Styled.OtDetailHeading>준비물</Styled.OtDetailHeading>
-        <Styled.OtDetailContent>노트북 또는 데스크탑, 그리고 열.정</Styled.OtDetailContent>
+        <Styled.OtDetailContent>노트북, 그리고 열.정</Styled.OtDetailContent>
         <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>
         <Styled.OtDetailContent>
           <Styled.SatisfactionSurveyLink

--- a/src/components/applyStatus/FinalConfirmReject/FinalConfirmReject.component.tsx
+++ b/src/components/applyStatus/FinalConfirmReject/FinalConfirmReject.component.tsx
@@ -1,5 +1,6 @@
 import { Application } from '@/types/dto';
 import { ProcessFail } from '@/components';
+import { CURRENT_GENERATION } from '@/constants';
 
 interface FinalConfirmRejectProps {
   application: Application;
@@ -11,8 +12,8 @@ const FinalConfirmReject = ({ application }: FinalConfirmRejectProps) => {
     <ProcessFail
       heading="저희는 언제나.. 기다리고 있을게요..!
   행복..하세요..!!(눈물)"
-      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up입니다. 어째서.. 12기에 합류하지 않는 것인가요..!
-  멋진 동료를 놓친 저희는 너무나 마음이 아픕니다.. 다음에 다시 기회가 된다면 Mash-Up으로 돌아와주세요! 12기 Rookie Recruiting 모든 프로세스에 임해주셔서 진심으로 감사드리며, 건강하고 행복하게 잘 지내세요! 다시 만나요!!`}
+      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up입니다. 어째서.. ${CURRENT_GENERATION}기에 합류하지 않는 것인가요..!
+  멋진 동료를 놓친 저희는 너무나 마음이 아픕니다.. 다음에 다시 기회가 된다면 Mash-Up으로 돌아와주세요! ${CURRENT_GENERATION}기 Rookie Recruiting 모든 프로세스에 임해주셔서 진심으로 감사드리며, 건강하고 행복하게 잘 지내세요! 다시 만나요!!`}
       survey
     />
   );

--- a/src/components/applyStatus/InterviewFail/InterviewFail.component.tsx
+++ b/src/components/applyStatus/InterviewFail/InterviewFail.component.tsx
@@ -1,6 +1,6 @@
 import { ProcessFail } from '@/components';
 import { Application } from '@/types/dto';
-import { TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, TEAM_NICK_NAME } from '@/constants';
 import { useDetectViewPort } from '@/hooks';
 
 interface InterviewFailProps {
@@ -12,17 +12,17 @@ const InterviewFail = ({ application }: InterviewFailProps) => {
   const { size } = useDetectViewPort();
   return (
     <ProcessFail
-      heading={`Mash-Up 12기 ${size === 'mobile' ? '\n' : ''}Rookie Recruiting \n${
-        TEAM_NICK_NAME[team.name]
-      } 면접 결과 안내`}
+      heading={`Mash-Up ${CURRENT_GENERATION}기 ${
+        size === 'mobile' ? '\n' : ''
+      }Rookie Recruiting \n${TEAM_NICK_NAME[team.name]} 면접 결과 안내`}
       paragraph={`안녕하세요, ${
         applicant.name
-      }님! Mash-Up입니다. 먼저 Mash-Up 12기에 많은 관심 가져 주시고, 귀한 시간 내어 지원해 주셔서 감사합니다. 보내주신 지원서와 면접 경험을 바탕으로 면밀히 살펴보고 ${
+      }님! Mash-Up입니다. 먼저 Mash-Up ${CURRENT_GENERATION}기에 많은 관심 가져 주시고, 귀한 시간 내어 지원해 주셔서 감사합니다. 보내주신 지원서와 면접 경험을 바탕으로 면밀히 살펴보고 ${
         TEAM_NICK_NAME[team.name]
       }이 추구하는 인재상과 잘 어울리는지 평가하였습니다.
   아쉽지만 ${applicant.name}님의 뛰어난 역량에도 불구하고, 제한된 모집 인원으로 인해 ${
         applicant.name
-      }님을 Mash-Up 12기에 모실 수 없게 되었습니다. Mash-Up 12기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며, 다음 기회에 인연이 될 수 있으면 좋겠습니다. 감사합니다.`}
+      }님을 Mash-Up ${CURRENT_GENERATION}기에 모실 수 없게 되었습니다. Mash-Up ${CURRENT_GENERATION}기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며, 다음 기회에 인연이 될 수 있으면 좋겠습니다. 감사합니다.`}
       survey
     />
   );

--- a/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
+++ b/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
@@ -1,5 +1,5 @@
 import { Application } from '@/types/dto';
-import { TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, TEAM_NICK_NAME } from '@/constants';
 
 import { useDetectViewPort, useErrorModalDialog, useLoadingModal } from '@/hooks';
 import { applicationApiService } from '@/api/services';
@@ -88,24 +88,25 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
       <Styled.InterviewPass>
         <Styled.ResultSection>
           <Styled.ResultMessage>
-            {'축하드립니다.\n'}Mash-Up 12기 {size === 'mobile' && '\n'}Rookie Recruiting{'\n'}
+            {'축하드립니다.\n'}Mash-Up {CURRENT_GENERATION}기 {size === 'mobile' && '\n'}Rookie
+            Recruiting{'\n'}
             <em>{TEAM_NICK_NAME[application.team.name]} 최종 합격</em>하셨습니다!
           </Styled.ResultMessage>
           <Styled.ResultDetail>
-            안녕하세요 {applicant.name}님, Mash-Up입니다. Mash-Up 12기에 많은 관심을 가지고 귀한
-            시간 내어 면접에 참여해 주셔서 감사합니다. 귀하께서는{' '}
-            {TEAM_NICK_NAME[application.team.name]} 면접에 합격하여 Mash-Up 12기 Rookie Recruiting에
-            최종 Crew로 선발 되셨습니다. 축하드립니다!! 마지막으로 12기 합류 여부에 대해
-            응답해주시면 감사하겠습니다. 기다릴게요!
+            안녕하세요 {applicant.name}님, Mash-Up입니다. Mash-Up {CURRENT_GENERATION}기에 많은
+            관심을 가지고 귀한 시간 내어 면접에 참여해 주셔서 감사합니다. 귀하께서는{' '}
+            {TEAM_NICK_NAME[application.team.name]} 면접에 합격하여 Mash-Up {CURRENT_GENERATION}기
+            Rookie Recruiting에 최종 Crew로 선발 되셨습니다. 축하드립니다!! 마지막으로{' '}
+            {CURRENT_GENERATION}기 합류 여부에 대해 응답해주시면 감사하겠습니다. 기다릴게요!
           </Styled.ResultDetail>
         </Styled.ResultSection>
         <Styled.ConfirmSection>
           <Styled.OtDateHeading>Mash-Up OT 일시</Styled.OtDateHeading>
-          <Styled.OtDate>4월 16일(토) 오후 2시 ~ 5시 - ZOOM</Styled.OtDate>
+          <Styled.OtDate>2월 11일(토) 오후 2시 ~ 5시</Styled.OtDate>
           <Styled.OtExplanationList>
             <li>
-              4월 13일(수) 오후 7시까지 12기 최종 합류 여부 응답 안 할 시 합류하지 않는 것으로
-              간주되니, 빠른 응답 부탁드립니다.
+              2월 8일(수) 오후 10시까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할 시 합류하지
+              않는 것으로 간주되니, 빠른 응답 부탁드립니다.
             </li>
             <li>전체 모임은 격주 토요일 오후 2시에 온라인으로 진행됩니다.</li>
             <li>궁금한 내용은 자주 묻는 질문에서 확인해주시거나, 채널톡으로 문의해주세요.</li>
@@ -116,21 +117,21 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
               onClick={handleOpenRejectInterviewModal}
               ref={rejectInterviewButtonRef}
             >
-              12기 합류 포기하기
+              {CURRENT_GENERATION}기 합류 포기하기
             </Styled.CancelButton>
             <Styled.ApprovalButton
               type="button"
               onClick={() => setIsOpenAcceptFinalConfirmModal(true)}
               ref={acceptInterviewButtonRef}
             >
-              12기 합류하기
+              {CURRENT_GENERATION}기 합류하기
             </Styled.ApprovalButton>
           </Styled.ConfirmButtonWrapper>
         </Styled.ConfirmSection>
       </Styled.InterviewPass>
       {isOpenRejectFinalConfirmModal && (
         <ConfirmRejectModalDialog
-          heading="Mash-Up 12기 포기하시겠습니까?"
+          heading={`Mash-Up ${CURRENT_GENERATION}기 포기하시겠습니까?`}
           paragraph="합류 포기시에 해당 선택에 대한 번복 불가한 점 참고 부탁드립니다."
           approvalButtonMessage="포기하기"
           cancelButtonMessage="취소"
@@ -143,7 +144,7 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
       )}
       {isOpenAcceptFinalConfirmModal && (
         <ConfirmAcceptModalDialog
-          heading="Mash-Up 12기 합류하시겠습니까?"
+          heading={`Mash-Up ${CURRENT_GENERATION}기 합류하시겠습니까?`}
           paragraph="합류 확인시에 해당 선택에 대한 번복 불가한 점 참고 부탁드립니다."
           inputPlaceHolder="합류합니다"
           approvalButtonMessage="합류하기"

--- a/src/components/applyStatus/InterviewReject/InterviewReject.component.tsx
+++ b/src/components/applyStatus/InterviewReject/InterviewReject.component.tsx
@@ -1,5 +1,6 @@
 import { Application } from '@/types/dto';
 import { ProcessFail } from '@/components';
+import { CURRENT_GENERATION } from '@/constants';
 
 interface InterviewRejectProps {
   application: Application;
@@ -10,7 +11,7 @@ const InterviewReject = ({ application }: InterviewRejectProps) => {
   return (
     <ProcessFail
       heading="인연이라면.. 저희 다시 만날 수 있겠죠..?"
-      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up Staff입니다. Mash-Up 12기에 많은 관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. 비록.. 면접에서 만나 뵙지 못했지만, 다음에 또 좋은 기회가 생긴다면 꼭 함께 할 수 있길 고대해봅니다. Mash-Up 12기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며 건강히 잘 지내시길 바랍니다.`}
+      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up Staff입니다. Mash-Up ${CURRENT_GENERATION}기에 많은 관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. 비록.. 면접에서 만나 뵙지 못했지만, 다음에 또 좋은 기회가 생긴다면 꼭 함께 할 수 있길 고대해봅니다. Mash-Up ${CURRENT_GENERATION}기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며 건강히 잘 지내시길 바랍니다.`}
     />
   );
 };

--- a/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
+++ b/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
@@ -1,3 +1,4 @@
+import { CURRENT_GENERATION } from '@/constants';
 import * as Styled from './ProcessFail.styled';
 
 interface ProcessFailProps {
@@ -20,8 +21,9 @@ const ProcessFail = ({ heading, paragraph, survey = false }: ProcessFailProps) =
           >
             https://forms.gle/36cdamKfsDFwqLUg7
           </Styled.SatisfactionSurveyLink>
-          Mash-Up 12기 모집 프로세스 경험에 대한 만족도 설문을 진행하고 있습니다. 선택사항이며,
-          지원자님의 소중한 답변을 통해 더 나은 프로세스를 만들어 성장하는 Mash-Up이 되겠습니다.
+          Mash-Up {CURRENT_GENERATION}기 모집 프로세스 경험에 대한 만족도 설문을 진행하고 있습니다.
+          선택사항이며, 지원자님의 소중한 답변을 통해 더 나은 프로세스를 만들어 성장하는 Mash-Up이
+          되겠습니다.
         </Styled.SurveyRequestMessage>
       )}
     </Styled.ProcessFail>

--- a/src/components/applyStatus/ScreeningFail/ScreeningFail.component.tsx
+++ b/src/components/applyStatus/ScreeningFail/ScreeningFail.component.tsx
@@ -1,5 +1,5 @@
 import { ProcessFail } from '@/components';
-import { TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, TEAM_NICK_NAME } from '@/constants';
 import { useDetectViewPort } from '@/hooks';
 import { Application } from '@/types/dto';
 
@@ -12,10 +12,10 @@ const ScreeningFail = ({ application }: ScreeningFailProps) => {
   const { applicant, team } = application;
   return (
     <ProcessFail
-      heading={`Mash-Up 12기 ${size === 'mobile' ? '\n' : ''}Rookie Recruiting \n${
-        TEAM_NICK_NAME[team.name]
-      } 지원 서류 결과 안내`}
-      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up입니다. Mash-Up 12기에 많은 관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. 보내주신 지원서를 면밀히 검토 했으나, 아쉽지만 ${applicant.name}님은 Mash-Up 12기 Rookie Recruiting 1차 서류 전형에 불합격하셨습니다. Mash-Up 12기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며, 다음 기회에 인연이 될 수 있으면 좋겠습니다. 감사합니다.`}
+      heading={`Mash-Up ${CURRENT_GENERATION}기 ${
+        size === 'mobile' ? '\n' : ''
+      }Rookie Recruiting \n${TEAM_NICK_NAME[team.name]} 지원 서류 결과 안내`}
+      paragraph={`안녕하세요 ${applicant.name}님, Mash-Up입니다. Mash-Up ${CURRENT_GENERATION}기에 많은 관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. 보내주신 지원서를 면밀히 검토 했으나, 아쉽지만 ${applicant.name}님은 Mash-Up ${CURRENT_GENERATION}기 Rookie Recruiting 1차 서류 전형에 불합격하셨습니다. Mash-Up ${CURRENT_GENERATION}기 Rookie Recruiting에 지원해주셔서 다시 한 번 감사드리며, 다음 기회에 인연이 될 수 있으면 좋겠습니다. 감사합니다.`}
     />
   );
 };

--- a/src/components/applyStatus/ScreeningPass/ScreeningPass.component.tsx
+++ b/src/components/applyStatus/ScreeningPass/ScreeningPass.component.tsx
@@ -1,5 +1,5 @@
 import { Application } from '@/types/dto';
-import { TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, TEAM_NICK_NAME } from '@/constants';
 
 import { useDetectViewPort, useErrorModalDialog, useLoadingModal } from '@/hooks';
 import { applicationApiService } from '@/api/services';
@@ -87,15 +87,16 @@ const ScreeningPass = ({ application, setSubmittedApplication }: ScreeningPassPr
       <Styled.ScreeningPass>
         <Styled.ResultSection>
           <Styled.ResultMessage>
-            {'축하드립니다.\n'}Mash-Up 12기 {size === 'mobile' && '\n'}Rookie Recruiting{'\n'}
+            {'축하드립니다.\n'}Mash-Up {CURRENT_GENERATION}기 {size === 'mobile' && '\n'}Rookie
+            Recruiting{'\n'}
             <em>{TEAM_NICK_NAME[application.team.name]} 서류 합격</em>하셨습니다!
           </Styled.ResultMessage>
           <Styled.ResultDetail>
-            안녕하세요 {applicant.name}님, Mash-Up입니다. Mash-Up 12기에 많은 관심을 가지고 귀한
-            시간 내어 지원해 주셔서 진심으로 감사드립니다. {applicant.name}님은 Mash-Up 12기 Rookie
-            Recruiting에서 지원하신 {TEAM_NICK_NAME[application.team.name]}의 1차 서류 전형에
-            합격하셨습니다. 다음 2차 면접 참여 여부에 대해 선택해주시면 감사하겠습니다. Mash-Up
-            면접은 온라인으로 진행됩니다.
+            안녕하세요 {applicant.name}님, Mash-Up입니다. Mash-Up {CURRENT_GENERATION}기에 많은
+            관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. {applicant.name}님은
+            Mash-Up {CURRENT_GENERATION}기 Rookie Recruiting에서 지원하신{' '}
+            {TEAM_NICK_NAME[application.team.name]}의 1차 서류 전형에 합격하셨습니다. 다음 2차 면접
+            참여 여부에 대해 선택해주시면 감사하겠습니다. Mash-Up 면접은 온라인으로 진행됩니다.
           </Styled.ResultDetail>
         </Styled.ResultSection>
         <Styled.ConfirmSection>

--- a/src/components/applyStatus/ScreeningWait/ScreeningWait.component.tsx
+++ b/src/components/applyStatus/ScreeningWait/ScreeningWait.component.tsx
@@ -8,8 +8,8 @@ const ScreeningWait = () => {
         {'Mash-Up Staff는 열심히 서류 검토 중.. \n조금만 기다려주세요!'}
       </Styled.StatusMessage>
       <Styled.StatusDescription>
-        Mash-Up Staff가 꼼꼼히 서류를 검토하고 있습니다. 4월 3일(일) 오전 10시에 서류 결과 발표를 꼭
-        확인해주세요!
+        Mash-Up Staff가 꼼꼼히 서류를 검토하고 있습니다. 1월 30일(월) 오전 10시에 서류 결과 발표를
+        꼭 확인해주세요!
       </Styled.StatusDescription>
     </Styled.ScreeningWait>
   );

--- a/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
+++ b/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
@@ -1,4 +1,5 @@
 import { ScreenReaderOnly } from '@/components';
+import { CURRENT_GENERATION } from '@/constants';
 import * as Styled from './RecruitingProcess.styled';
 
 const RecruitingProcess = () => {
@@ -48,7 +49,7 @@ const RecruitingProcess = () => {
             <Styled.Note>오후 7시</Styled.Note>
           </Styled.ListItem>
           <Styled.ListItem>
-            <Styled.SubHeading>12기 OT</Styled.SubHeading>
+            <Styled.SubHeading>{CURRENT_GENERATION}기 OT</Styled.SubHeading>
             <Styled.Date>
               <ScreenReaderOnly>2023년 2월 11일 토요일</ScreenReaderOnly>
               <time aria-hidden dateTime="2023-02-11">

--- a/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
+++ b/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
@@ -4,6 +4,7 @@ import { getDifferenceOfDates, RECRUITMENT_START_KST_DATE } from '@/utils/date';
 import type { DateDifference } from '@/utils/date';
 import { useState, useEffect } from 'react';
 
+import { CURRENT_GENERATION } from '@/constants';
 import * as Styled from './RecruitingRemainder.styled';
 
 const RecruitingRemainder = () => {
@@ -34,7 +35,7 @@ const RecruitingRemainder = () => {
   return (
     <Styled.Container>
       <Styled.RemainderContainer>
-        <Styled.Heading>Mash-Up 13기 모집</Styled.Heading>
+        <Styled.Heading>Mash-Up {CURRENT_GENERATION}기 모집</Styled.Heading>
         {!isPreviousDayOfRecruitingStart && !isRunOutTimeOfRecruitingStart && (
           <Styled.Counter>
             <Styled.D />

--- a/src/constants/application.ts
+++ b/src/constants/application.ts
@@ -1,0 +1,1 @@
+export const CURRENT_GENERATION = 13;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,4 @@ export * from './viewport';
 export * from './team';
 export * from './platform';
 export * from './aos';
+export * from './application';

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -20,12 +20,22 @@ export const teamNames = {
 } as const;
 
 export const teamIds = {
-  [teamNames.design]: 5,
-  [teamNames.web]: 6,
-  [teamNames.android]: 7,
-  [teamNames.ios]: 8,
-  [teamNames.node]: 9,
-  [teamNames.spring]: 10,
+  12: {
+    [teamNames.design]: 5,
+    [teamNames.web]: 6,
+    [teamNames.android]: 7,
+    [teamNames.ios]: 8,
+    [teamNames.node]: 9,
+    [teamNames.spring]: 10,
+  },
+  13: {
+    [teamNames.spring]: 11,
+    [teamNames.design]: 12,
+    [teamNames.web]: 13,
+    [teamNames.android]: 14,
+    [teamNames.ios]: 15,
+    [teamNames.node]: 16,
+  },
 } as const;
 
 export const TEAM_NICK_NAME: Record<TeamName, string> = {

--- a/src/utils/application.ts
+++ b/src/utils/application.ts
@@ -1,0 +1,16 @@
+import { Application } from '@/types/dto';
+
+export const sortByGenerationAndTeam = (applications: Application[]) => {
+  const copyApplications = [...applications];
+
+  copyApplications.sort(
+    ({ team: teamA }, { team: teamB }) => teamA.name.charCodeAt(0) - teamB.name.charCodeAt(0),
+  );
+  copyApplications.sort(
+    (
+      { generationResponse: { generationNumber: generationNumberA } },
+      { generationResponse: { generationNumber: generationNumberB } },
+    ) => generationNumberB - generationNumberA,
+  );
+  return copyApplications;
+};


### PR DESCRIPTION
## 변경사항

- 서버에서 기수별로 팀을 구분하는 기준이 teamId이기 때문에 13기 팀에 알맞는 팀의 id를 상수값으로 추가해줍니다. 추가해준 상수값을 이용해 createApplication API에 적용해주었습니다.
- 지원서를 제출했는지 판단하는 boolean 변수인 isSubmitted의 조건이 CURRENT_GENERATION의(현재는 13기) 지원서에서만 판단되게끔 수정해주었습니다.
- 지원현황 목록의 정렬 순서를 1순위는 최근 기수 순서, 2순위는 팀의 이름(abc순) 오름차순으로 정렬해주었습니다.
- 12기때 사용했던 서류지연 Alert을 제거해주었습니다.
- 서비스내 기수 정보가 들어가는 텍스트들을 모두 CURRENT_GENERATION 상수를 이용해서 관리하게끔 수정해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
