### PR TITLE
모집 시작 워딩 변경

### DIFF
--- a/src/components/common/Footer/Footer.component.tsx
+++ b/src/components/common/Footer/Footer.component.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
         <Styled.Footer currentPage={currentPage}>
           <Styled.FooterInner>
             <Styled.Copyright currentPage={currentPage}>
-              © Mash-Up 2022. Made in Seoul.
+              © Mash-Up 2023. Made in Seoul.
             </Styled.Copyright>
             <Styled.ExternalLinkWrapper currentPage={currentPage}>
               <a

--- a/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
+++ b/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
@@ -23,7 +23,7 @@ const RecruitingProcess = () => {
             <Styled.SubHeading>서류 결과 발표</Styled.SubHeading>
             <Styled.Date>
               <ScreenReaderOnly>2023년 1월 30일 월요일</ScreenReaderOnly>
-              <time aria-hidden dateTime="2022-04-03">
+              <time aria-hidden dateTime="2023-01-30">
                 01.30(월)
               </time>
             </Styled.Date>

--- a/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
+++ b/src/components/home/RecruitingRemainder/RecruitingRemainder.component.tsx
@@ -35,7 +35,7 @@ const RecruitingRemainder = () => {
   return (
     <Styled.Container>
       <Styled.RemainderContainer>
-        <Styled.Heading>Mash-Up {CURRENT_GENERATION}기 모집</Styled.Heading>
+        <Styled.Heading>Mash-Up {CURRENT_GENERATION}기 모집 시작까지</Styled.Heading>
         {!isPreviousDayOfRecruitingStart && !isRunOutTimeOfRecruitingStart && (
           <Styled.Counter>
             <Styled.D />


### PR DESCRIPTION
## 변경사항

- 모집 시작이라는 현재의 워딩이 모집 마감과 혼동될 여지가 있어 보다 명확하게 모집 시작까지라는 워딩으로 변경합니다.
- Footer에 노출되는 연도가 2022 -> 2023으로 변경되어 대응합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
