### PR TITLE
QA 환경에서 사용한 recruitStartDate를 정상적으로 수정한다

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,7 +10,7 @@ export const [
   INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
   AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
 ] = [
-  new Date('2023-01-01T00:00:00+09:00'),
+  new Date('2023-01-11T00:00:00+09:00'),
   new Date('2023-01-25T23:59:59+09:00'),
   new Date('2023-01-30T10:00:00+09:00'),
   new Date('2023-02-07T19:00:00+09:00'),


### PR DESCRIPTION
## 변경사항

- QA 환경에서 사용한 recruitStartDate를 정상적으로 수정합니다. 1월 1일 -> 1월 11일

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
