### PR TITLE
지원 상태 상세 UI에 기수별 예외케이스 대응

### DIFF
--- a/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
+++ b/src/components/applyStatus/ApplyStatusDetail/ApplyStatusDetail.component.tsx
@@ -9,6 +9,7 @@ import {
   FinalConfirmAccept,
   FinalConfirmReject,
 } from '@/components';
+import { CURRENT_GENERATION } from '@/constants';
 import { Application } from '@/types/dto';
 import { RecruitingProgressStatus } from '@/utils/date';
 import { useState } from 'react';
@@ -21,7 +22,11 @@ interface ApplyStatusDetailProps {
 
 const ApplyStatusDetail = ({ applications, recruitingProgressStatus }: ApplyStatusDetailProps) => {
   const [submittedApplication, setSubmittedApplication] = useState(
-    applications.find((application) => application.status === 'SUBMITTED'),
+    applications.find(
+      (application) =>
+        application.status === 'SUBMITTED' &&
+        application.generationResponse.generationNumber === CURRENT_GENERATION,
+    ),
   );
 
   if (!submittedApplication || recruitingProgressStatus === 'AFTER-FIRST-SEMINAR') return null;

--- a/src/components/applyStatus/ApplyStatusLayout/ApplyStatusLayout.component.tsx
+++ b/src/components/applyStatus/ApplyStatusLayout/ApplyStatusLayout.component.tsx
@@ -1,4 +1,5 @@
 import { StatusList, ApplyStatusDetail } from '@/components';
+import { CURRENT_GENERATION } from '@/constants';
 import { Application } from '@/types/dto';
 import { RecruitingProgressStatus } from '@/utils/date';
 import * as Styled from './ApplyStatusLayout.styled';
@@ -9,7 +10,10 @@ interface ApplyStatusLayoutProps {
 }
 
 const ApplyStatusLayout = ({ applications, recruitingProgressStatus }: ApplyStatusLayoutProps) => {
-  const isSubmitted = applications.some(({ status }) => status === 'SUBMITTED');
+  const isSubmitted = applications.some(
+    ({ status, generationResponse: { generationNumber } }) =>
+      status === 'SUBMITTED' && generationNumber === CURRENT_GENERATION,
+  );
   return (
     <Styled.Layout>
       {isSubmitted && (

--- a/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
+++ b/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
@@ -108,7 +108,7 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
               2월 8일(수) 오후 10시까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할 시 합류하지
               않는 것으로 간주되니, 빠른 응답 부탁드립니다.
             </li>
-            <li>전체 모임은 격주 토요일 오후 2시에 온라인으로 진행됩니다.</li>
+            <li>전체 모임은 격주 토요일 오후 2시에 온/오프라인을 병행하며 진행됩니다.</li>
             <li>궁금한 내용은 자주 묻는 질문에서 확인해주시거나, 채널톡으로 문의해주세요.</li>
           </Styled.OtExplanationList>
           <Styled.ConfirmButtonWrapper>

--- a/src/components/applyStatus/ScreeningPass/ScreeningPass.component.tsx
+++ b/src/components/applyStatus/ScreeningPass/ScreeningPass.component.tsx
@@ -96,7 +96,7 @@ const ScreeningPass = ({ application, setSubmittedApplication }: ScreeningPassPr
             관심을 가지고 귀한 시간 내어 지원해 주셔서 진심으로 감사드립니다. {applicant.name}님은
             Mash-Up {CURRENT_GENERATION}기 Rookie Recruiting에서 지원하신{' '}
             {TEAM_NICK_NAME[application.team.name]}의 1차 서류 전형에 합격하셨습니다. 다음 2차 면접
-            참여 여부에 대해 선택해주시면 감사하겠습니다. Mash-Up 면접은 온라인으로 진행됩니다.
+            참여 여부에 대해 선택해주시면 감사하겠습니다.
           </Styled.ResultDetail>
         </Styled.ResultSection>
         <Styled.ConfirmSection>
@@ -110,14 +110,13 @@ const ScreeningPass = ({ application, setSubmittedApplication }: ScreeningPassPr
           </Styled.InterviewDate>
           <Styled.InterviewExplanationList>
             <li>
-              4월 4일(월) 오전 10시까지 면접 참여 여부 선택 안할 시 면접 불참으로 간주되니 빠른 응답
+              1월 31일(화) 오후 9시까지 면접 참여 여부 선택 안할 시 면접 불참으로 간주되니 빠른 응답
               부탁드립니다.
             </li>
             <li>
               면접 일정 조율이 불가피하게 필요하거나 궁금한 사항이 있으면 채널톡으로 문의해주시길
               바랍니다.
             </li>
-            <li>면접은 온라인으로 진행됩니다.</li>
           </Styled.InterviewExplanationList>
           <Styled.ConfirmButtonWrapper>
             <Styled.CancelButton


### PR DESCRIPTION
## 변경사항

- 기존에는 기수에 상관없이 지원 완료된 지원서가 하나라도 있다면 지원 상태 상세 UI를 보여주었던것을 현재 기수에 지원 완료된 지원서가 있을때만 보여주게끔 수정해주었습니다.
- 지원 상태 상세에 노출되는 지원서를 현재 기수의 지원서가 될 수 있도록 조건식을 수정해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
