### PR TITLE
지원상태 상세 메시지의 워딩 수정

### DIFF
--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -38,10 +38,6 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
         </Styled.OtDetailContent>
         <Styled.OtExplanationList>
           <li>
-            OT 때 짧게 자기소개를 하는 시간이 있어요! 정말 간단한 자기소개라고 생각하시고 편하게
-            참여해주시면 됩니다!
-          </li>
-          <li>
             모집 프로세스 만족도 설문 작성은 선택사항이며, 지원자님의 소중한 답변을 통해 더 나은
             프로세스를 만들어 성장하는 Mash-Up이 되겠습니다.
           </li>

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.styled.ts
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.styled.ts
@@ -124,6 +124,7 @@ export const OtDetailContent = styled.time`
 export const SatisfactionSurveyLink = styled.a`
   ${({ theme }) => css`
     color: ${theme.colors.white};
+    text-decoration: underline;
     word-break: break-all;
   `}
 `;

--- a/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
+++ b/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
@@ -19,11 +19,22 @@ const InterviewAccept = ({ application }: InterviewAcceptProps) => {
         <Styled.NoticeMessage>곧 면접에서 만나요!</Styled.NoticeMessage>
         <Styled.NoticeDetailListHeading>면접 꿀팁!</Styled.NoticeDetailListHeading>
         <Styled.NoticeDetailList>
-          <li>코로나 19 상황을 고려해 비대면 화상면접으로 진행됩니다.</li>
-          <li>면접 시간 10분 전에는 준비를 마쳐주세요!</li>
-          <li>목소리를 잘 들을 수 있게 조용한 공간에서 면접에 참여해주세요.</li>
-          <li>면접 장소 노출이 부담스럽다면 배경 설정 고!</li>
-          <li>다른 지원자가 얘기할 때에는 함께 경청해주세요!</li>
+          {application.team.name === 'iOS' ? (
+            <>
+              <li>면접 일시 최소 10분 전에는 면접 장소에 도착해주세요!</li>
+              <li>다른 지원자가 얘기할 때에는 함께 경청해주세요!</li>
+              <li>복장은 편하게 입고 오시면 돼요!</li>
+              <li>긴장은 Nope! 본인의 역량을 마음껏 보여주세요 \( ^0^ )/</li>
+            </>
+          ) : (
+            <>
+              <li>면접 일시 10분 전에는 준비를 마쳐주세요!</li>
+              <li>목소리를 잘 들을 수 있게 조용한 공간에서 면접에 참여해주세요.</li>
+              <li>면접 장소 노출이 부담스럽다면 배경 설정 고!</li>
+              <li>다른 지원자가 얘기할 때에는 함께 경청해주세요!</li>
+              <li>긴장은 Nope! 본인의 역량을 마음껏 보여주세요 \( ^0^ )/</li>
+            </>
+          )}
         </Styled.NoticeDetailList>
       </Styled.NoticeSection>
       <Styled.InterviewDetailSection>
@@ -35,8 +46,10 @@ const InterviewAccept = ({ application }: InterviewAcceptProps) => {
               }`
             : '채널톡으로 문의해주세요.'}
         </Styled.InterviewDetailContent>
-        <Styled.InterviewDetailHeading>면접 장소</Styled.InterviewDetailHeading>
-        <Styled.InterviewDetailContent>Zoom</Styled.InterviewDetailContent>
+        <Styled.InterviewDetailHeading>면접 유형</Styled.InterviewDetailHeading>
+        <Styled.InterviewDetailContent>
+          {application.team.name === 'iOS' ? '오프라인' : '온라인 (Zoom)'}
+        </Styled.InterviewDetailContent>
         <Styled.InterviewDetailHeading>면접 장소 상세 주소</Styled.InterviewDetailHeading>
         <Styled.InterviewDetailContent>
           <Styled.InterviewLink

--- a/src/components/applyStatus/InterviewAccept/InterviewAccept.styled.ts
+++ b/src/components/applyStatus/InterviewAccept/InterviewAccept.styled.ts
@@ -139,6 +139,7 @@ export const InterviewLink = styled.a`
     ${theme.fonts.kr.bold22};
     color: ${theme.colors.white};
     letter-spacing: -0.08rem;
+    text-decoration: underline;
     word-break: break-all;
 
     @media (max-width: ${theme.breakPoint.media.tabletM}) {

--- a/src/components/applyStatus/InterviewAccept/InterviewAccept.styled.ts
+++ b/src/components/applyStatus/InterviewAccept/InterviewAccept.styled.ts
@@ -72,7 +72,7 @@ export const NoticeDetailListHeading = styled.span`
 export const NoticeDetailList = styled.ul`
   ${({ theme }) => css`
     ${theme.fonts.kr.medium15};
-    width: 30.17rem;
+    width: 40rem;
     margin-left: 1.83rem;
     color: ${theme.colors.white};
     letter-spacing: -0.08rem;

--- a/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
+++ b/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
@@ -145,7 +145,7 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
       {isOpenAcceptFinalConfirmModal && (
         <ConfirmAcceptModalDialog
           heading={`Mash-Up ${CURRENT_GENERATION}기 합류하시겠습니까?`}
-          paragraph="합류 확인시에 해당 선택에 대한 번복 불가한 점 참고 부탁드립니다."
+          paragraph=""
           inputPlaceHolder="합류합니다"
           approvalButtonMessage="합류하기"
           cancelButtonMessage="취소"

--- a/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
+++ b/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
@@ -105,7 +105,7 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
           <Styled.OtDate>2월 11일(토) 오후 2시 ~ 5시</Styled.OtDate>
           <Styled.OtExplanationList>
             <li>
-              2월 8일(수) 오후 10시까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할 시 합류하지
+              2월 8일(수) 오후 9시까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할 시 합류하지
               않는 것으로 간주되니, 빠른 응답 부탁드립니다.
             </li>
             <li>전체 모임은 격주 토요일 오후 2시에 온/오프라인을 병행하며 진행됩니다.</li>


### PR DESCRIPTION
## 변경사항

- 지원 상태 상세에서 안내해주는 메시지의 워딩 및 스타일을 변경해주었습니다.
  - 합류 응답에 대해 되묻는 Dialog에서 Description 부분을 제거
  - 최종 합류 안내 메시지에서 OT에서 자기소개 세션이 있다는 메시지를 제거
  - 안내 메시지 중 링크 요소에 `text-decoration: under-line` 스타일을 적용
  - 이번 기수 오프라인 면접이 있는 플랫폼이 존재하여 이에 따라 노출하는 메시지를 분기처리
  - 면접 참여 여부 응답 기한을 오후 10시 -> 오후 9시로 수정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
