### PR TITLE
서버쪽과 TeamId 상수값이 일치하도록 수정

### DIFF
--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -29,12 +29,12 @@ export const teamIds = {
     [teamNames.spring]: 10,
   },
   13: {
-    [teamNames.spring]: 11,
-    [teamNames.design]: 12,
-    [teamNames.web]: 13,
-    [teamNames.android]: 14,
-    [teamNames.ios]: 15,
-    [teamNames.node]: 16,
+    [teamNames.design]: 11,
+    [teamNames.web]: 12,
+    [teamNames.android]: 13,
+    [teamNames.ios]: 14,
+    [teamNames.node]: 15,
+    [teamNames.spring]: 16,
   },
 } as const;
 


### PR DESCRIPTION
## 변경사항

- 서버에서 dev환경에서의 TeamId와 production환경에서의 TeamId가 다르게 설정되어있어 지원서 생성시 선택한 플랫폼이 아닌 다른 플랫폼의 설문지를 응답받게 되는 이슈가 있어 이를 해결해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
