### PR TITLE
모집 종료 요일 오타 수정

### DIFF
--- a/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
+++ b/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
@@ -15,7 +15,7 @@ const RecruitingProcess = () => {
             <ScreenReaderOnly>2023년 1월 11일 수요일부터 2023년 1월 25일 수요일</ScreenReaderOnly>
             <Styled.Date aria-hidden>
               <time dateTime="2023-01-11">01.11(수)</time>&nbsp;~&nbsp;
-              <time dateTime="2023-01-25">01.25(화)</time>
+              <time dateTime="2023-01-25">01.25(수)</time>
             </Styled.Date>
             <Styled.Note>23:59:59 마감</Styled.Note>
           </Styled.ListItem>


### PR DESCRIPTION
## 변경사항

- 1월 25일(화) -> 1월 25일(수) 모집 종료 요일 오타를 수정합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
