### PR TITLE
오프라인 면접을 진행하는 플랫폼의 면접 장소 링크 추가

### DIFF
--- a/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
+++ b/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
@@ -7,6 +7,8 @@ interface InterviewAcceptProps {
   application: Application;
 }
 
+// TODO: 현재 특정 플랫폼을 기준으로 분기 처리하여 온/오프라인 구분중
+// TODO: 서버와 함께 추가로 기능 개발하여 온/오프라인 분기 처리 해야함
 const InterviewAccept = ({ application }: InterviewAcceptProps) => {
   const interviewStartDateInstance = new Date(application.result.interviewStartedAt || '');
 
@@ -54,17 +56,24 @@ const InterviewAccept = ({ application }: InterviewAcceptProps) => {
           </Styled.InterviewDetailContent>
           <Styled.InterviewDetailHeading>면접 장소 상세 주소</Styled.InterviewDetailHeading>
           <Styled.InterviewDetailContent>
-            <Styled.InterviewLink
-              href={
-                application.result.interviewGuideLink ??
-                'https://us02web.zoom.us/j/7167277658?pwd=eHBEdXF4a1REdHpIK3RVVXRpWTJiQT09'
-              }
-              target="_blank"
-              rel="noreferrer"
-            >
-              {application.result.interviewGuideLink ??
-                'https://us02web.zoom.us/j/7167277658?pwd=eHBEdXF4a1REdHpIK3RVVXRpWTJiQT09'}
-            </Styled.InterviewLink>
+            {application.team.name === 'iOS' ? (
+              <Styled.InterviewLink
+                href="https://naver.me/5D31cBCT"
+                target="_blank"
+                rel="noreferrer"
+              >
+                서울특별시 강남구 테헤란로 133, 3층
+              </Styled.InterviewLink>
+            ) : (
+              <Styled.InterviewLink
+                href={application.result.interviewGuideLink ?? ''}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {application.result.interviewGuideLink ??
+                  '페이지 우측 하단 채팅 상담을 통해 문의해주세요'}
+              </Styled.InterviewLink>
+            )}
           </Styled.InterviewDetailContent>
         </Styled.InterviewDetailSection>
       </Styled.ScreeningAccept>

--- a/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
+++ b/src/components/applyStatus/InterviewAccept/InterviewAccept.component.tsx
@@ -26,7 +26,6 @@ const InterviewAccept = ({ application }: InterviewAcceptProps) => {
             {application.team.name === 'iOS' ? (
               <>
                 <li>면접 일시 최소 10분 전에는 면접 장소에 도착해주세요!</li>
-                <li>다른 지원자가 얘기할 때에는 함께 경청해주세요!</li>
                 <li>복장은 편하게 입고 오시면 돼요!</li>
                 <li>긴장은 Nope! 본인의 역량을 마음껏 보여주세요 \( ^0^ )/</li>
               </>


### PR DESCRIPTION
## 변경사항

- 오프라인 면접을 진행하는 플랫폼의 장소와 장소를 안내해주는 링크를 추가해줍니다. 현재는 갑작스럽게 iOS 플랫폼만 오프라인으로 진행하게 되어 임시적으로만 처리해놓은 상태고 추후 개선해야 할 사항을 TODO 주석으로 남겨놓았습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
