### PR TITLE
최종 합격자에게 안내되는 문구를 일부 수정

### DIFF
--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -27,7 +27,7 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
           <Styled.OtDetailHeading>Mash-Up OT일시</Styled.OtDetailHeading>
           <Styled.OtDetailContent>2월 11일(토) 오후 2시 ~ 5시</Styled.OtDetailContent>
           <Styled.OtDetailHeading>준비물</Styled.OtDetailHeading>
-          <Styled.OtDetailContent>노트북, 그리고 열.정</Styled.OtDetailContent>
+          <Styled.OtDetailContent>노트북(선택), 그리고 열.정</Styled.OtDetailContent>
           <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>
           <Styled.OtDetailContent>
             <Styled.SatisfactionSurveyLink

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -31,11 +31,11 @@ const FinalConfirmAccept = ({ application }: FinalConfirmAcceptProps) => {
           <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>
           <Styled.OtDetailContent>
             <Styled.SatisfactionSurveyLink
-              href="https://forms.gle/36cdamKfsDFwqLUg7"
+              href="https://forms.gle/UEVfw3DFvERMa9cy9"
               target="_blank"
               rel="noreferrer"
             >
-              https://forms.gle/36cdamKfsDFwqLUg7
+              https://forms.gle/UEVfw3DFvERMa9cy9
             </Styled.SatisfactionSurveyLink>
           </Styled.OtDetailContent>
           <Styled.OtExplanationList>

--- a/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
+++ b/src/components/applyStatus/InterviewPass/InterviewPass.component.tsx
@@ -110,10 +110,10 @@ const InterviewPass = ({ application, setSubmittedApplication }: InterviewPassPr
             <Styled.OtDate>2월 11일(토) 오후 2시 ~ 5시</Styled.OtDate>
             <Styled.OtExplanationList>
               <li>
-                2월 8일(수) 오후 9시까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할 시
-                합류하지 않는 것으로 간주되니, 빠른 응답 부탁드립니다.
+                2월 8일(수) 오후 11시 59분 59초까지 {CURRENT_GENERATION}기 최종 합류 여부 응답 안 할
+                시 합류하지 않는 것으로 간주되니, 빠른 응답 부탁드립니다.
               </li>
-              <li>전체 모임은 격주 토요일 오후 2시에 온/오프라인을 병행하며 진행됩니다.</li>
+              <li>전체 모임은 격주 토요일 오후 2시 ~ 5시에 온/오프라인을 병행하며 진행됩니다.</li>
               <li>
                 궁금한 내용은 자주 묻는 질문에서 확인해주시거나, 페이지 우측 하단에 있는 채팅 상담을
                 통해 문의해주세요.

--- a/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
+++ b/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
@@ -15,11 +15,11 @@ const ProcessFail = ({ heading, paragraph, survey = false }: ProcessFailProps) =
       {survey && (
         <Styled.SurveyRequestMessage>
           <Styled.SatisfactionSurveyLink
-            href="https://forms.gle/36cdamKfsDFwqLUg7"
+            href="https://forms.gle/UEVfw3DFvERMa9cy9"
             target="_blank"
             rel="noreferrer"
           >
-            https://forms.gle/36cdamKfsDFwqLUg7
+            https://forms.gle/UEVfw3DFvERMa9cy9
           </Styled.SatisfactionSurveyLink>
           Mash-Up {CURRENT_GENERATION}기 모집 프로세스 경험에 대한 만족도 설문을 진행하고 있습니다.
           선택사항이며, 지원자님의 소중한 답변을 통해 더 나은 프로세스를 만들어 성장하는 Mash-Up이


### PR DESCRIPTION
## 변경사항

- 최종 합류 응답 기한이 수정되어 문구를 수정해주었습니다. (기존) 오후 9시 -> (현재) 오후 11시 59분 59초
- 모집 프로세스 피드백 설문 링크를 12기 설문지에서 13기 설문지로 수정해주었습니다.


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링
- 
### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
