### PR TITLE
Modal오픈시 초기 포커스를 Modal 내부 focusable의 첫번째 요소로 변경

### DIFF
--- a/src/components/common/Modal/Modal.component.tsx
+++ b/src/components/common/Modal/Modal.component.tsx
@@ -59,27 +59,35 @@ const Modal = ({
         'input, button, textarea, select, [href], [tabindex]',
       );
 
-      if (focusableNodeList) {
-        const firstFocusableNode = focusableNodeList[0];
-        const lastFocusableNode = focusableNodeList[focusableNodeList.length - 1];
+      if (!focusableNodeList) return;
 
-        if (e.target === firstFocusableNode && e.shiftKey && e.key === 'Tab') {
-          e.preventDefault();
-          lastFocusableNode.focus();
-        }
-        if (e.target === lastFocusableNode && !e.shiftKey && e.key === 'Tab') {
-          e.preventDefault();
-          firstFocusableNode.focus();
-        }
+      const firstFocusableNode = focusableNodeList[0];
+      const lastFocusableNode = focusableNodeList[focusableNodeList.length - 1];
+
+      if (e.target === firstFocusableNode && e.shiftKey && e.key === 'Tab') {
+        e.preventDefault();
+        lastFocusableNode.focus();
+      }
+      if (e.target === lastFocusableNode && !e.shiftKey && e.key === 'Tab') {
+        e.preventDefault();
+        firstFocusableNode.focus();
       }
     };
 
     if (escClose) window.addEventListener('keyup', handleCloseModalWithEscHandler);
 
     if (mounted) {
-      dialogRef.current?.focus();
+      const focusableNodeList = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'input, button, textarea, select, [href], [tabindex]',
+      );
 
-      window.addEventListener('keydown', handleFocusTrap);
+      if (focusableNodeList) {
+        const firstFocusableNode = focusableNodeList[0];
+
+        firstFocusableNode?.focus();
+
+        window.addEventListener('keydown', handleFocusTrap);
+      }
     }
 
     if (!mounted) setMounted(true);


### PR DESCRIPTION
## 변경사항

- Modal오픈시 기존에는 ModalElement에 포커스가 가게끔 구현되어 있던것을 Modal 내부 focusable의 첫번째 요소에 포커스가 되게끔 수정해주었습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
