### PR TITLE
특정 라우트에서 채널톡 아이콘을 show하는 로직을 제거

### DIFF
--- a/src/components/common/ChannelTalk/ChannelTalk.component.tsx
+++ b/src/components/common/ChannelTalk/ChannelTalk.component.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useState } from 'react';
 import ChannelService from '@/utils/services/ChannelService';
-import { useDetectViewPort } from '@/hooks';
-import { useRouter } from 'next/router';
-import { PATH_NAME } from '@/constants';
 
 const ChannelTalk = () => {
   const [channelServiceInstance, setChannelServiceInstance] = useState<any>(null);
-  const router = useRouter();
-  const { size } = useDetectViewPort();
 
   useEffect(() => {
     setChannelServiceInstance(new ChannelService());
@@ -18,14 +13,6 @@ const ChannelTalk = () => {
       pluginKey: process.env.NEXT_PUBLIC_CHANNEL_PLUGIN,
     });
   }, [channelServiceInstance]);
-
-  useEffect(() => {
-    if (router.pathname === PATH_NAME.RECRUIT_PAGE && size === 'mobile') {
-      channelServiceInstance?.hideChannelButton();
-    } else {
-      channelServiceInstance?.showChannelButton();
-    }
-  }, [channelServiceInstance, router.pathname, size]);
 
   return null;
 };


### PR DESCRIPTION
## 변경사항

- #245 의 임시 대응으로 모바일 환경에서 지원서 페이지를 제외한곳에서 showChannelButton 메서드를 호출하던 로직을 제거합니다.

### 작업 유형
<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
