### PR TITLE
Modal 컴포넌트 mount시 focus되는 요소 변경

### DIFF
--- a/src/components/common/Modal/Modal.component.tsx
+++ b/src/components/common/Modal/Modal.component.tsx
@@ -28,7 +28,7 @@ const Modal = ({
 }: ModalProps) => {
   const [mounted, setMounted] = useState(false);
 
-  const dialogRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
 
   const handleCloseModalWithMouseHandler: MouseEventHandler<HTMLDivElement> = ({
     target,
@@ -55,7 +55,7 @@ const Modal = ({
     };
 
     const handleFocusTrap = (e: KeyboardEvent) => {
-      const focusableNodeList = dialogRef.current?.querySelectorAll<HTMLElement>(
+      const focusableNodeList = modalRef.current?.querySelectorAll<HTMLElement>(
         'input, button, textarea, select, [href], [tabindex]',
       );
 
@@ -77,17 +77,9 @@ const Modal = ({
     if (escClose) window.addEventListener('keyup', handleCloseModalWithEscHandler);
 
     if (mounted) {
-      const focusableNodeList = dialogRef.current?.querySelectorAll<HTMLElement>(
-        'input, button, textarea, select, [href], [tabindex]',
-      );
+      modalRef.current?.focus();
 
-      if (focusableNodeList) {
-        const firstFocusableNode = focusableNodeList[0];
-
-        firstFocusableNode?.focus();
-
-        window.addEventListener('keydown', handleFocusTrap);
-      }
+      window.addEventListener('keydown', handleFocusTrap);
     }
 
     if (!mounted) setMounted(true);
@@ -112,7 +104,7 @@ const Modal = ({
     <Portal elementId="modal-root" mounted={mounted}>
       <Styled.OverSizeModal>
         <Styled.Modal
-          ref={dialogRef}
+          ref={modalRef}
           tabIndex={-1}
           onClick={deemClose ? handleCloseModalWithMouseHandler : undefined}
         >

--- a/src/components/common/Modal/Modal.styled.ts
+++ b/src/components/common/Modal/Modal.styled.ts
@@ -29,5 +29,9 @@ export const Modal = styled.div`
     width: 100%;
     height: 100%;
     padding: 0 2rem;
+
+    &:focus-visible {
+      outline: none;
+    }
   `}
 `;


### PR DESCRIPTION
## 변경사항

- Modal 컴포넌트 mount시 first focusable 요소에 자동으로 focus되던것을 Modal요소 자체에 focus되는것으로 변경합니다.
- focus되는 Modal 컴포넌트 요소가 focus-visible시에 outline style을 none으로 설정합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
