### PR TITLE
CMS 개행 렌더링 처리

### DIFF
--- a/src/components/recruit/RecruitEditorContainer/RecruitEditorContainer.styled.ts
+++ b/src/components/recruit/RecruitEditorContainer/RecruitEditorContainer.styled.ts
@@ -12,6 +12,7 @@ export const Container = styled.div`
     p {
       ${theme.fonts.kr.medium16};
       width: 100%;
+      min-height: 2.4rem;
 
       @media (max-width: ${theme.breakPoint.media.tabletL}) {
         width: 60rem;


### PR DESCRIPTION
## 변경사항

- 어드민 상에서 반영한 개행 상황이 textContent가 비어있는 p태그로 렌더링되어 높이가 지정되지 않는 이슈가 발생하여 최소 높이를 16px * line-height(1.5) = 24px(2.4rem)으로 지정해주어 개행을 렌더링할 수 있도록 대응합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
