### PR TITLE
Feat: 14기 모집 예정일자를 23년 11월 -> 24년 1분기로 수정한다

### DIFF
--- a/src/components/home/NotRecruitmentPeriod/NotRecruitmentPeriod.component.tsx
+++ b/src/components/home/NotRecruitmentPeriod/NotRecruitmentPeriod.component.tsx
@@ -19,7 +19,7 @@ const NotRecruitmentPeriod = ({ setIsOpenModal }: NotRecruitmentPeriodProps) => 
       <Styled.Dialog>
         <Styled.Notify>지금은 모집 기간이 아니에요!</Styled.Notify>
         <Styled.Paragraph>
-          다음 기수 모집 시작은{'\n'}23년 11월 이후로 예정되어 있습니다.
+          다음 기수 모집 시작은{'\n'}24년 1분기로 예정되어 있습니다.
         </Styled.Paragraph>
         <Styled.GoToOfficialPage href="https://mash-up.kr/">
           공식 홈페이지 바로가기


### PR DESCRIPTION
## 변경사항

- 기존 14기 모집 예정일자 안내가 `23년 11월 이후`로 되어있던것을 `24년 1분기`로 수정합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 단순 문자열 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
