### PR TITLE
Feat: 지원서 생성, 조회에 필요한 teamId를 api를 통해 응답받도록 개선한다

### DIFF
--- a/pages/apply/[platformName].tsx
+++ b/pages/apply/[platformName].tsx
@@ -1,4 +1,4 @@
-import { applicationApiService } from '@/api/services';
+import { applicationApiService, teamApiService } from '@/api/services';
 import { ApplyLayout } from '@/components';
 import {
   PlatformHeadings,
@@ -10,11 +10,10 @@ import {
   ERROR_PAGE,
   HOME_PAGE,
   NOT_FOUND_PAGE,
-  teamIds,
   teamNames,
   Teams,
 } from '@/constants';
-import { Application } from '@/types/dto';
+import { Application, TeamName } from '@/types/dto';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
@@ -50,17 +49,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const currentApplyPlatform = teamNames[context.params?.platformName as Teams];
-
-  if (!currentApplyPlatform) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: NOT_FOUND_PAGE,
-      },
-    };
-  }
-
   const session = await getSession(context);
 
   if (!session) {
@@ -73,6 +61,28 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
 
   try {
+    const teams = (
+      await teamApiService.getTeams({
+        accessToken: session?.accessToken,
+        generationNumber: CURRENT_GENERATION,
+      })
+    ).data;
+
+    const teamIds = teams.reduce<Record<TeamName, number>>((acc, { name, teamId }) => {
+      return { ...acc, [name]: teamId };
+    }, {} as Record<TeamName, number>);
+
+    const currentApplyPlatform = teamNames[context.params?.platformName as Teams];
+
+    if (!currentApplyPlatform) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: NOT_FOUND_PAGE,
+        },
+      };
+    }
+
     const applications = (
       await applicationApiService.getApplications({
         accessToken: session?.accessToken,
@@ -86,15 +96,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     const currentApplication = applications.find(
       ({ team, generationResponse: { generationNumber } }) =>
-        team.teamId === teamIds[CURRENT_GENERATION][currentApplyPlatform] &&
-        generationNumber === CURRENT_GENERATION,
+        team.teamId === teamIds[currentApplyPlatform] && generationNumber === CURRENT_GENERATION,
     );
 
     if (!currentApplication) {
       const application = await applicationApiService.createMyApplication({
         accessToken: session.accessToken,
-        teamId: teamIds[CURRENT_GENERATION][currentApplyPlatform],
+        teamId: teamIds[currentApplyPlatform],
       });
+
       return {
         props: {
           application: application?.data,

--- a/src/api/services/team.ts
+++ b/src/api/services/team.ts
@@ -1,4 +1,4 @@
-import { TeamsResponse } from '@/types/dto';
+import { TeamsRequest, TeamsResponse } from '@/types/dto';
 import BaseApiService from './base';
 
 class TeamApiService extends BaseApiService {
@@ -6,8 +6,13 @@ class TeamApiService extends BaseApiService {
     super('teams');
   }
 
-  public getTeams(): Promise<TeamsResponse> {
-    return this.http.get('').then(BaseApiService.handleResponse).catch(BaseApiService.handleError);
+  public getTeams({ accessToken, generationNumber }: TeamsRequest): Promise<TeamsResponse> {
+    return this.http
+      .get(`?generationNumber=${generationNumber}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
   }
 }
 

--- a/src/constants/team.ts
+++ b/src/constants/team.ts
@@ -19,34 +19,6 @@ export const teamNames = {
   spring: 'Spring',
 } as const;
 
-export const teamIds = {
-  12: {
-    [teamNames.design]: 5,
-    [teamNames.web]: 6,
-    [teamNames.android]: 7,
-    [teamNames.ios]: 8,
-    [teamNames.node]: 9,
-    [teamNames.spring]: 10,
-  },
-  13: {
-    [teamNames.design]: 11,
-    [teamNames.web]: 12,
-    [teamNames.android]: 13,
-    [teamNames.ios]: 14,
-    [teamNames.node]: 15,
-    [teamNames.spring]: 16,
-  },
-  // TODO: 14기 팀 id 확정되면 수정
-  14: {
-    [teamNames.design]: 17,
-    [teamNames.web]: 18,
-    [teamNames.android]: 19,
-    [teamNames.ios]: 20,
-    [teamNames.node]: 21,
-    [teamNames.spring]: 22,
-  },
-} as const;
-
 export const TEAM_NICK_NAME: Record<TeamName, string> = {
   Design: 'Product Design Team',
   Android: 'Android Team',
@@ -58,4 +30,3 @@ export const TEAM_NICK_NAME: Record<TeamName, string> = {
 
 export type Teams = ValueOf<typeof teamUrls>;
 export type TeamNames = ValueOf<typeof teamNames>;
-export type TeamIds = ValueOf<typeof teamIds>;

--- a/src/types/dto/team.ts
+++ b/src/types/dto/team.ts
@@ -1,4 +1,4 @@
-import { BaseResponse } from '@/types/dto/base';
+import { BaseRequest, BaseResponse } from '@/types/dto/base';
 
 export type TeamName = 'Design' | 'Web' | 'Android' | 'iOS' | 'Node' | 'Spring';
 export interface Team {
@@ -8,4 +8,7 @@ export interface Team {
 
 export interface TeamsResponseData extends Array<Team> {}
 
+export interface TeamsRequest extends BaseRequest {
+  generationNumber: number;
+}
 export interface TeamsResponse extends BaseResponse<TeamsResponseData> {}


### PR DESCRIPTION
## 변경사항

- 지원서 생성, 조회에 필요한 teamId를 기존 상수로 관리했던것을 api를 통해 응답받도록 개선한다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
