### PR TITLE
Feat: 면접 일자가 하루일때와 이틀일때 UI를 각각 다르게 조건부 렌더링한다

### DIFF
--- a/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
+++ b/src/components/home/RecruitingProcess/RecruitingProcess.component.tsx
@@ -23,7 +23,7 @@ const RecruitingProcess = ({ recruitSchedule }: RecruitingProcessProps) => {
   const DAYJS_RECRUITMENT_END_KST_DATE = dayjs(RECRUITMENT_ENDED);
   const DAYJS_SCREENING_RESULT_ANNOUNCED_KST_DATE = dayjs(SCREENING_RESULT_ANNOUNCED);
   const DAYJS_INTERVIEW_START_KST_DATE = dayjs(INTERVIEW_START);
-  const DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE = dayjs(INTERVIEW_END);
+  const DAYJS_INTERVIEW_END_KST_DATE = dayjs(INTERVIEW_END);
   const DAYJS_INTERVIEW_RESULT_ANNOUNCED_KST_DATE = dayjs(INTERVIEW_RESULT_ANNOUNCED);
   const DAYJS_AFTER_FIRST_SEMINAR_JOIN_KST_DATE = dayjs(AFTER_FIRST_SEMINAR_JOIN);
 
@@ -77,23 +77,30 @@ const RecruitingProcess = ({ recruitSchedule }: RecruitingProcessProps) => {
           </Styled.ListItem>
           <Styled.ListItem>
             <Styled.SubHeading>온/오프라인 면접</Styled.SubHeading>
-            <ScreenReaderOnly>{`${DAYJS_INTERVIEW_START_KST_DATE.format('YYYY년 M월 D일')} ${
-              DAYS[DAYJS_INTERVIEW_START_KST_DATE.day()]
-            }요일에서 ${DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE.format('YYYY년 M월 D일')} ${
-              DAYS[DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE.day()]
-            }요일`}</ScreenReaderOnly>
+            <ScreenReaderOnly>
+              {`${DAYJS_INTERVIEW_START_KST_DATE.format('YYYY년 M월 D일')} ${
+                DAYS[DAYJS_INTERVIEW_START_KST_DATE.day()]
+              }요일에서 ${DAYJS_INTERVIEW_END_KST_DATE.format('YYYY년 M월 D일')} ${
+                DAYS[DAYJS_INTERVIEW_END_KST_DATE.day()]
+              }요일`}
+            </ScreenReaderOnly>
             <Styled.Date aria-hidden>
               <time
                 dateTime={DAYJS_INTERVIEW_START_KST_DATE.format('YYYY-MM-DD')}
               >{`${DAYJS_INTERVIEW_START_KST_DATE.format('MM.DD')}(${
                 DAYS[DAYJS_INTERVIEW_START_KST_DATE.day()]
               })`}</time>
-              &nbsp;~&nbsp;
-              <time
-                dateTime={DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE.format('YYYY-MM-DD')}
-              >{`${DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE.format('MM.DD')}(${
-                DAYS[DAYJS_INTERVIEW_INTERVIEW_END_KST_DATE.day()]
-              })`}</time>
+              {DAYJS_INTERVIEW_START_KST_DATE.format('YYYY-MM-DD') !==
+                DAYJS_INTERVIEW_END_KST_DATE.format('YYYY-MM-DD') && (
+                <>
+                  &nbsp;~&nbsp;
+                  <time
+                    dateTime={DAYJS_INTERVIEW_END_KST_DATE.format('YYYY-MM-DD')}
+                  >{`${DAYJS_INTERVIEW_END_KST_DATE.format('MM.DD')}(${
+                    DAYS[DAYJS_INTERVIEW_END_KST_DATE.day()]
+                  })`}</time>
+                </>
+              )}
             </Styled.Date>
             <Styled.Note>상세일정 이메일로 전달</Styled.Note>
           </Styled.ListItem>


### PR DESCRIPTION
## 변경사항

- 면접 일자가 하루일때와 이틀일때 UI를 각각 다르게 조건부 렌더링한다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
