### PR TITLE
Feat: 세미나 러닝 타임을 시작 시간을 기점으로 +3시간 동안 자동으로 계산되도록 한다

### DIFF
--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -1,4 +1,4 @@
-import { CURRENT_GENERATION, DAYS, TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, DAYS, TEAM_NICK_NAME, SEMINAR_RUNNING_HOUR } from '@/constants';
 import { Application, RecruitSchedule } from '@/types/dto';
 import { StatusDetailBackground } from '@/components';
 import dayjs from 'dayjs';
@@ -17,7 +17,9 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
   const afterFirstSeminalJoinDayjs = dayjs(AFTER_FIRST_SEMINAR_JOIN);
 
   const afterFirstSeminalJoinDate = afterFirstSeminalJoinDayjs.format(
-    `M월 D일(${DAYS[afterFirstSeminalJoinDayjs.day()]})`,
+    `M월 D일(${DAYS[afterFirstSeminalJoinDayjs.day()]}) H시 ~ ${
+      afterFirstSeminalJoinDayjs.hour() + SEMINAR_RUNNING_HOUR
+    }시`,
   );
 
   const groupChatInviteDayjs = afterFirstSeminalJoinDayjs.date(
@@ -42,7 +44,7 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
         </Styled.NoticeSection>
         <Styled.OtDetailSection>
           <Styled.OtDetailHeading>Mash-Up OT일시</Styled.OtDetailHeading>
-          <Styled.OtDetailContent>{`${afterFirstSeminalJoinDate} 오후 2시 ~ 5시`}</Styled.OtDetailContent>
+          <Styled.OtDetailContent>{`${afterFirstSeminalJoinDate}`}</Styled.OtDetailContent>
           <Styled.OtDetailHeading>준비물</Styled.OtDetailHeading>
           <Styled.OtDetailContent>노트북(선택), 그리고 열.정</Styled.OtDetailContent>
           <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,3 +5,4 @@ export * from './platform';
 export * from './aos';
 export * from './application';
 export * from './date';
+export * from './recruit';

--- a/src/constants/recruit.ts
+++ b/src/constants/recruit.ts
@@ -44,3 +44,5 @@ export const INTERVIEW_LOCATION: {
     },
   },
 } as const;
+
+export const SEMINAR_RUNNING_HOUR = 3;


### PR DESCRIPTION
## 변경사항

- 세미나 러닝 타임을 시작 시간을 기점으로 +3시간 동안 자동으로 계산되도록 한다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
