### PR TITLE
15기 운영관련 안내 변경사항 배포

### DIFF
--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -50,11 +50,11 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
           <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>
           <Styled.OtDetailContent>
             <Styled.SatisfactionSurveyLink
-              href="https://forms.gle/bWbvuG2XVm9z3eNw9"
+              href="https://forms.gle/bfpbkhrZckeg5Sim8"
               target="_blank"
               rel="noreferrer"
             >
-              https://forms.gle/bWbvuG2XVm9z3eNw9
+              https://forms.gle/bfpbkhrZckeg5Sim8
             </Styled.SatisfactionSurveyLink>
           </Styled.OtDetailContent>
           <Styled.OtExplanationList>

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -23,7 +23,7 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
   );
 
   const groupChatInviteDayjs = afterFirstSeminalJoinDayjs.date(
-    afterFirstSeminalJoinDayjs.date() - 6,
+    afterFirstSeminalJoinDayjs.date() - 2,
   );
 
   const groupChatInviteDate = groupChatInviteDayjs.format(

--- a/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
+++ b/src/components/applyStatus/FinalConfirmAccept/FinalConfirmAccept.component.tsx
@@ -1,4 +1,4 @@
-import { CURRENT_GENERATION, DAYS, TEAM_NICK_NAME } from '@/constants';
+import { CURRENT_GENERATION, DAYS, TEAM_NICK_NAME, SEMINAR_RUNNING_HOUR } from '@/constants';
 import { Application, RecruitSchedule } from '@/types/dto';
 import { StatusDetailBackground } from '@/components';
 import dayjs from 'dayjs';
@@ -17,7 +17,9 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
   const afterFirstSeminalJoinDayjs = dayjs(AFTER_FIRST_SEMINAR_JOIN);
 
   const afterFirstSeminalJoinDate = afterFirstSeminalJoinDayjs.format(
-    `M월 D일(${DAYS[afterFirstSeminalJoinDayjs.day()]})`,
+    `M월 D일(${DAYS[afterFirstSeminalJoinDayjs.day()]}) H시 ~ ${
+      afterFirstSeminalJoinDayjs.hour() + SEMINAR_RUNNING_HOUR
+    }시`,
   );
 
   const groupChatInviteDayjs = afterFirstSeminalJoinDayjs.date(
@@ -42,7 +44,7 @@ const FinalConfirmAccept = ({ application, recruitSchedule }: FinalConfirmAccept
         </Styled.NoticeSection>
         <Styled.OtDetailSection>
           <Styled.OtDetailHeading>Mash-Up OT일시</Styled.OtDetailHeading>
-          <Styled.OtDetailContent>{`${afterFirstSeminalJoinDate} 오후 2시 ~ 5시`}</Styled.OtDetailContent>
+          <Styled.OtDetailContent>{`${afterFirstSeminalJoinDate}`}</Styled.OtDetailContent>
           <Styled.OtDetailHeading>준비물</Styled.OtDetailHeading>
           <Styled.OtDetailContent>노트북(선택), 그리고 열.정</Styled.OtDetailContent>
           <Styled.OtDetailHeading>모집 프로세스 만족도 조사 설문 링크</Styled.OtDetailHeading>

--- a/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
+++ b/src/components/applyStatus/ProcessFail/ProcessFail.component.tsx
@@ -15,11 +15,11 @@ const ProcessFail = ({ heading, paragraph, survey = false }: ProcessFailProps) =
       {survey && (
         <Styled.SurveyRequestMessage>
           <Styled.SatisfactionSurveyLink
-            href="https://forms.gle/bWbvuG2XVm9z3eNw9"
+            href="https://forms.gle/bfpbkhrZckeg5Sim8"
             target="_blank"
             rel="noreferrer"
           >
-            https://forms.gle/bWbvuG2XVm9z3eNw9
+            https://forms.gle/bfpbkhrZckeg5Sim8
           </Styled.SatisfactionSurveyLink>
           Mash-Up {CURRENT_GENERATION}기 모집 프로세스 경험에 대한 만족도 설문을 진행하고 있습니다.
           선택사항이며, 지원자님의 소중한 답변을 통해 더 나은 프로세스를 만들어 성장하는 Mash-Up이

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,3 +5,4 @@ export * from './platform';
 export * from './aos';
 export * from './application';
 export * from './date';
+export * from './recruit';

--- a/src/constants/recruit.ts
+++ b/src/constants/recruit.ts
@@ -44,3 +44,5 @@ export const INTERVIEW_LOCATION: {
     },
   },
 } as const;
+
+export const SEMINAR_RUNNING_HOUR = 3;


### PR DESCRIPTION
## 변경사항

- 세미나 러닝 타임을 시작 시간으로부터 3시간 뒤에 끝나도록 로직을 작성하여 세미나 시작 시간만 관리하면 되도록 변경
- 리크루팅 설문 링크를 15기 링크로 변경
- 신입 기수 시작시 매쉬업 전체 단톡방 초대 일정을 세미나 시작 -2일로 변경

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 배포 관련


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
