### PR TITLE
Env: node version을 20으로 강제한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "4.5.5"
   },
   "engines": {
-    "node": "^16.x || ^18.x",
+    "node": "^20.x",
     "npm": "please-use-yarn",
     "yarn": "^1.22.x"
   },
@@ -84,5 +84,6 @@
       "yarn lint:code-fix --cache",
       "yarn lint:style-fix --cache"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha512.ff4579ab459bb25aa7c0ff75b62acebe576f6084b36aa842971cf250a5d8c6cd3bc9420b22ce63c7f93a0857bc6ef29291db39c3e7a23aab5adfd5a4dd6c5d71"
 }


### PR DESCRIPTION
## 변경사항

- node version을 20으로 강제
  - 22버전이 현재 LTS이나 lottie-web 라이브러리에서 21이상의 node 버전 사용시 별도의 방어 코드없이 작동하지 않는 [이슈](https://github.com/airbnb/lottie-web/issues/3047)가 존재하기 때문에 20으로 설정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 패키지 추가 및 버전 변경

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)
